### PR TITLE
Access single item resource lists at index 0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,19 +26,19 @@ resource "aws_route53_record" "validation" {
   count = "${var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(var.subject_alternative_names) + 1 : 0}"
 
   zone_id = "${var.zone_id}"
-  name    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_name")}"
-  type    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_type")}"
+  name    = "${lookup(aws_acm_certificate.this[0].domain_validation_options[count.index], "resource_record_name")}"
+  type    = "${lookup(aws_acm_certificate.this[0].domain_validation_options[count.index], "resource_record_type")}"
   ttl     = 60
 
   records = [
-    "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}"
+    "${lookup(aws_acm_certificate.this[0].domain_validation_options[count.index], "resource_record_value")}"
   ]
 }
 
 resource "aws_acm_certificate_validation" "this" {
   count = "${var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0}"
 
-  certificate_arn = "${aws_acm_certificate.this.arn}"
+  certificate_arn = "${aws_acm_certificate.this[0].arn}"
 
   validation_record_fqdns = [
     "${aws_route53_record.validation.*.fqdn}",


### PR DESCRIPTION
Resources with a count of 1 are now output as a list. The source code has been updated to access the item at index 0 to fix issues introduced by Terraform 0.12.

Please see upgrade guide for more info: https://www.terraform.io/upgrade-guides/0-12.html#working-with-count-on-resources