### PR TITLE
fix format issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,10 +29,7 @@ resource "aws_route53_record" "validation" {
   name    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_name")}"
   type    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_type")}"
   ttl     = 60
-
-  records = [
-    "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}"
-  ]
+  records = ["${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}"]
 }
 
 resource "aws_acm_certificate_validation" "this" {


### PR DESCRIPTION
This fixes a formatting issue that can be problematic when running tests in CI pipelines.

```
$ terraform fmt --diff --check
main.tf
diff a/main.tf b/main.tf
--- /var/folders/20/59pbfvbd0q52q8kv8j6hwdmr0000gn/T/248116428	2019-05-30 13:26:49.000000000 -0400
+++ /var/folders/20/59pbfvbd0q52q8kv8j6hwdmr0000gn/T/754506683	2019-05-30 13:26:49.000000000 -0400
@@ -31,7 +31,7 @@
   ttl     = 60

   records = [
-    "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}"
+    "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}",
   ]
 }
```