### PR TITLE
Terraform.012 upgrade

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,51 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ else }}
+{{ range .Unreleased.Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ if .CommitGroups -}}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ else }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,10 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/terraform-aws-modules/terraform-aws-acm
+options:
+  header:
+    pattern: "^(.*)$"
+    pattern_maps:
+      - Subject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v1.8.1
   hooks:
     - id: terraform_fmt
-    - id: terraform_docs
+#    - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
   rev: v2.1.0
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+
+
+<a name="v2.0.0"></a>
+## [v2.0.0] - 2019-06-05
+
+- Upgraded to Terraform 0.12 and improved support for wildcard domain names
+
+
+<a name="v1.3.0"></a>
+## [v1.3.0] - 2019-05-30
+
+- fix format issue ([#6](https://github.com/terraform-aws-modules/terraform-aws-acm/issues/6))
+
+
+<a name="v1.2.0"></a>
+## [v1.2.0] - 2019-02-14
+
+- Added multiple records for route53 validation (related to [#1](https://github.com/terraform-aws-modules/terraform-aws-acm/issues/1))
+
+
+<a name="v1.1.0"></a>
+## [v1.1.0] - 2019-02-01
+
+- Fixed bug when creation was disabled
+
+
+<a name="v1.0.0"></a>
+## v1.0.0 - 2018-12-13
+
+- Updated readme
+- Initial commit with all the code
+
+
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-acm/compare/v2.0.0...HEAD
+[v2.0.0]: https://github.com/terraform-aws-modules/terraform-aws-acm/compare/v1.3.0...v2.0.0
+[v1.3.0]: https://github.com/terraform-aws-modules/terraform-aws-acm/compare/v1.2.0...v1.3.0
+[v1.2.0]: https://github.com/terraform-aws-modules/terraform-aws-acm/compare/v1.1.0...v1.2.0
+[v1.1.0]: https://github.com/terraform-aws-modules/terraform-aws-acm/compare/v1.0.0...v1.1.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: changelog release
+
+changelog:
+	git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+
+release:
+	semtag final -s minor

--- a/README.md
+++ b/README.md
@@ -2,17 +2,25 @@
 
 Terraform module which creates ACM certificates and validates them using Route53 DNS (recommended) or e-mail.
 
+## Terraform versions
+
+Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
+
+Terraform 0.11. Pin module version to `~> v1.0`. Submit pull-requests to `terraform011` branch.
+
 ## Usage with Route53 DNS validation (recommended)
 
 ```hcl
 module "acm" {
-  source = "terraform-aws-modules/acm/aws"
+  source  = "terraform-aws-modules/acm/aws"
+  version = "~> v2.0"
 
   domain_name  = "my-domain.com"
   zone_id      = "Z2ES7B9AZ6SHAE"
 
   subject_alternative_names = [
     "*.my-domain.com",
+    "app.sub.my-domain.com",
   ]
 
   tags = {
@@ -53,6 +61,7 @@ module "acm" {
 ## Notes
 
 * For use in an automated pipeline consider setting the `wait_for_validation = false` to avoid waiting for validation to complete or error after a 45 minute timeout.
+* `domain_name` can not be wildcard, but `subject_alternative_names` can include wildcards.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -4,22 +4,23 @@ variable "domain_name" {
 }
 
 resource "aws_route53_zone" "this" {
-  name = "${var.domain_name}"
+  name = var.domain_name
 }
 
 module "acm" {
   source = "../../"
 
-  domain_name = "${var.domain_name}"
-  zone_id     = "${aws_route53_zone.this.zone_id}"
+  domain_name = var.domain_name
+  zone_id     = aws_route53_zone.this.zone_id
 
   subject_alternative_names = [
     "*.${var.domain_name}",
+    "new.sub.${var.domain_name}",
   ]
 
   wait_for_validation = false # true
 
   tags = {
-    Name = "${var.domain_name}"
+    Name = var.domain_name
   }
 }

--- a/examples/complete-dns-validation/outputs.tf
+++ b/examples/complete-dns-validation/outputs.tf
@@ -1,14 +1,29 @@
 output "this_acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value       = "${module.acm.this_acm_certificate_arn}"
+  value       = module.acm.this_acm_certificate_arn
 }
 
 output "this_acm_certificate_domain_validation_options" {
   description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
-  value       = "${module.acm.this_acm_certificate_domain_validation_options}"
+  value       = module.acm.this_acm_certificate_domain_validation_options
 }
 
 output "this_acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
-  value       = "${module.acm.this_acm_certificate_validation_emails}"
+  value       = module.acm.this_acm_certificate_validation_emails
+}
+
+output "validation_route53_record_fqdns" {
+  description = "List of FQDNs built using the zone domain and name."
+  value       = module.acm.validation_route53_record_fqdns
+}
+
+output "distinct_domain_names" {
+  description = "List of distinct domains names used for the validation."
+  value       = module.acm.distinct_domain_names
+}
+
+output "validation_domains" {
+  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
+  value       = module.acm.validation_domains
 }

--- a/examples/complete-email-validation/main.tf
+++ b/examples/complete-email-validation/main.tf
@@ -4,14 +4,14 @@ variable "domain_name" {
 }
 
 resource "aws_route53_zone" "this" {
-  name = "${var.domain_name}"
+  name = var.domain_name
 }
 
 module "acm" {
   source = "../../"
 
-  domain_name = "${var.domain_name}"
-  zone_id     = "${aws_route53_zone.this.zone_id}"
+  domain_name = var.domain_name
+  zone_id     = aws_route53_zone.this.zone_id
 
   subject_alternative_names = [
     "*.${var.domain_name}",
@@ -20,6 +20,6 @@ module "acm" {
   validation_method = "EMAIL"
 
   tags = {
-    Name = "${var.domain_name}"
+    Name = var.domain_name
   }
 }

--- a/examples/complete-email-validation/outputs.tf
+++ b/examples/complete-email-validation/outputs.tf
@@ -1,14 +1,14 @@
 output "this_acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value       = "${module.acm.this_acm_certificate_arn}"
+  value       = module.acm.this_acm_certificate_arn
 }
 
 output "this_acm_certificate_domain_validation_options" {
   description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
-  value       = "${module.acm.this_acm_certificate_domain_validation_options}"
+  value       = module.acm.this_acm_certificate_domain_validation_options
 }
 
 output "this_acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
-  value       = "${module.acm.this_acm_certificate_validation_emails}"
+  value       = module.acm.this_acm_certificate_validation_emails
 }

--- a/main.tf
+++ b/main.tf
@@ -1,43 +1,50 @@
+locals {
+  // Get distinct list of domains and SANs
+  distinct_domain_names = distinct(concat([var.domain_name], data.template_file.breakup_san.*.rendered))
+
+  // Copy domain_validation_options for the distinct domain names
+  validation_domains = [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)]
+}
+
+data "template_file" "breakup_san" {
+  count = length(var.subject_alternative_names)
+
+  template = replace(var.subject_alternative_names[count.index], "*.", "")
+}
+
 resource "aws_acm_certificate" "this" {
-  count = "${var.create_certificate}"
+  count = var.create_certificate ? 1 : 0
 
-  domain_name               = "${var.domain_name}"
-  subject_alternative_names = ["${var.subject_alternative_names}"]
-  validation_method         = "${var.validation_method}"
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = var.validation_method
 
-  tags = "${var.tags}"
+  tags = var.tags
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-//data "aws_acm_certificate" "this" {
-//  count = "${1 - var.create_certificate}"
-//
-//  domain = "${var.domain_name}"
-//
-//  types = ["${var.acm_certificate_types}"]
-//  statuses = ["${var.acm_certificate_statuses}"]
-//  most_recent = "${var.acm_certificate_most_recent}"
-//}
-
 resource "aws_route53_record" "validation" {
-  count = "${var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(var.subject_alternative_names) + 1 : 0}"
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
-  zone_id = "${var.zone_id}"
-  name    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_name")}"
-  type    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_type")}"
+  zone_id = var.zone_id
+  name    = local.validation_domains[count.index]["resource_record_name"]
+  type    = local.validation_domains[count.index]["resource_record_type"]
   ttl     = 60
-  records = ["${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}"]
+
+  records = [
+    local.validation_domains[count.index]["resource_record_value"]
+  ]
+
+  allow_overwrite = var.validation_allow_overwrite_records
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count = "${var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0}"
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0
 
-  certificate_arn = "${aws_acm_certificate.this.arn}"
+  certificate_arn = aws_acm_certificate.this[0].arn
 
-  validation_record_fqdns = [
-    "${aws_route53_record.validation.*.fqdn}",
-  ]
+  validation_record_fqdns = aws_route53_record.validation.*.fqdn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,29 @@
 output "this_acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value       = "${element(concat(aws_acm_certificate.this.*.arn, list("")), 0)}"
+  value       = element(concat(aws_acm_certificate.this.*.arn, [""]), 0)
 }
 
 output "this_acm_certificate_domain_validation_options" {
   description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
-  value       = "${flatten(aws_acm_certificate.this.*.domain_validation_options)}"
+  value       = flatten(aws_acm_certificate.this.*.domain_validation_options)
 }
 
 output "this_acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
-  value       = "${flatten(aws_acm_certificate.this.*.validation_emails)}"
+  value       = flatten(aws_acm_certificate.this.*.validation_emails)
+}
+
+output "validation_route53_record_fqdns" {
+  description = "List of FQDNs built using the zone domain and name."
+  value       = [] #aws_route53_record.validation.*.fqdn
+}
+
+output "distinct_domain_names" {
+  description = "List of distinct domains names used for the validation."
+  value       = local.distinct_domain_names
+}
+
+output "validation_domains" {
+  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
+  value       = local.validation_domains
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "this_acm_certificate_validation_emails" {
 
 output "validation_route53_record_fqdns" {
   description = "List of FQDNs built using the zone domain and name."
-  value       = [] #aws_route53_record.validation.*.fqdn
+  value       = aws_route53_record.validation.*.fqdn
 }
 
 output "distinct_domain_names" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,40 +1,53 @@
 variable "create_certificate" {
   description = "Whether to create ACM certificate"
+  type        = bool
   default     = true
 }
 
 variable "validate_certificate" {
   description = "Whether to validate certificate by creating Route53 record"
+  type        = bool
+  default     = true
+}
+
+variable "validation_allow_overwrite_records" {
+  description = "Whether to allow overwrite of Route53 records"
+  type        = bool
   default     = true
 }
 
 variable "wait_for_validation" {
   description = "Whether to wait for the validation to complete"
+  type        = bool
   default     = true
 }
 
 variable "domain_name" {
   description = "A domain name for which the certificate should be issued"
+  type        = string
   default     = ""
 }
 
 variable "subject_alternative_names" {
   description = "A list of domains that should be SANs in the issued certificate"
+  type        = list(string)
   default     = []
 }
 
 variable "validation_method" {
   description = "Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform."
+  type        = string
   default     = "DNS"
 }
 
 variable "zone_id" {
   description = "The ID of the hosted zone to contain this record."
+  type        = string
   default     = ""
 }
 
 variable "tags" {
   description = "A mapping of tags to assign to the resource"
-  type        = "map"
+  type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
Based on #7.

Also fixed support for wildcard domains (ref, #8 #3), which became possible with Terraform 0.12. See the usage of `for` in `main.tf`.

Thanks to everyone who pushed code and proposed different solutions for wildcard support.