### PR TITLE
feat: validation_allow_overwrite_records variable to allow overwrite records

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,8 @@ repos:
   rev: v2.1.0
   hooks:
     - id: check-merge-conflict
+    - id: check-symlinks
+    - id: detect-private-key
+    - id: end-of-file-fixer
+    - id: requirements-txt-fixer
+    - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ module "acm" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| create\_certificate | Whether to create ACM certificate | string | `"true"` | no |
-| domain\_name | A domain name for which the certificate should be issued | string | `""` | no |
+| create\_certificate | Whether to create ACM certificate | string | `true` | no |
+| domain\_name | A domain name for which the certificate should be issued | string | `` | no |
 | subject\_alternative\_names | A list of domains that should be SANs in the issued certificate | list | `[]` | no |
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
-| validate\_certificate | Whether to validate certificate by creating Route53 record | string | `"true"` | no |
-| validation\_method | Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform. | string | `"DNS"` | no |
-| wait\_for\_validation | Whether to wait for the validation to complete | string | `"true"` | no |
-| zone\_id | The ID of the hosted zone to contain this record. | string | `""` | no |
+| validate\_certificate | Whether to validate certificate by creating Route53 record | string | `true` | no |
+| validation\_allow\_overwrite\_records | Whether to allow overwrite of Route53 records | string | `true` | no |
+| validation\_method | Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform. | string | `DNS` | no |
+| wait\_for\_validation | Whether to wait for the validation to complete | string | `true` | no |
+| zone\_id | The ID of the hosted zone to contain this record. | string | `` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,8 @@ resource "aws_route53_record" "validation" {
   type    = "${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_type")}"
   ttl     = 60
   records = ["${lookup(aws_acm_certificate.this.domain_validation_options[count.index], "resource_record_value")}"]
+
+  allow_overwrite = "${var.validation_allow_overwrite_records}"
 }
 
 resource "aws_acm_certificate_validation" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "validate_certificate" {
   default     = true
 }
 
+variable "validation_allow_overwrite_records" {
+  description = "Whether to allow overwrite of Route53 records"
+  default     = true
+}
+
 variable "wait_for_validation" {
   description = "Whether to wait for the validation to complete"
   default     = true


### PR DESCRIPTION
Include `validation_allow_overwrite_records` variable to deal with multiple certificates with the same domain name. 
