### PR TITLE
Used string manipulation instead of templating to remove characters from SAN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,11 @@
 locals {
   // Get distinct list of domains and SANs
-  distinct_domain_names = distinct(concat([var.domain_name], data.template_file.breakup_san.*.rendered))
+  distinct_domain_names = distinct(
+    concat(
+      [var.domain_name],
+      split(":", replace(join(":", var.subject_alternative_names), "*.", ""))
+    )
+  )
 
   // Copy domain_validation_options for the distinct domain names
   validation_domains = [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)]


### PR DESCRIPTION
# Description

Hi, was experiencing the issue described [here](https://github.com/terraform-aws-modules/terraform-aws-acm/issues/10)

I believe this change creates the list that was being done in the templating, my local testing shows that it no longer errors out but I have not tried the scenarios listed in the issue.

I left the original template bit in as I was just trying to get this working, but can remove it. 