### PR TITLE
fix: remove domain verification enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.14.0
+  rev: v1.17.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -82,11 +82,9 @@ module "acm" {
 
 | Name | Description |
 |------|-------------|
-| distinct\_domain\_names | List of distinct domains names used for the validation. |
 | this\_acm\_certificate\_arn | The ARN of the certificate |
 | this\_acm\_certificate\_domain\_validation\_options | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
 | this\_acm\_certificate\_validation\_emails | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
-| validation\_domains | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |
 | validation\_route53\_record\_fqdns | List of FQDNs built using the zone domain and name. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-dns-validation/README.md
+++ b/examples/complete-dns-validation/README.md
@@ -29,11 +29,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| distinct\_domain\_names | List of distinct domains names used for the validation. |
 | this\_acm\_certificate\_arn | The ARN of the certificate |
 | this\_acm\_certificate\_domain\_validation\_options | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
 | this\_acm\_certificate\_validation\_emails | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
-| validation\_domains | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |
 | validation\_route53\_record\_fqdns | List of FQDNs built using the zone domain and name. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-dns-validation/outputs.tf
+++ b/examples/complete-dns-validation/outputs.tf
@@ -17,13 +17,3 @@ output "validation_route53_record_fqdns" {
   description = "List of FQDNs built using the zone domain and name."
   value       = module.acm.validation_route53_record_fqdns
 }
-
-output "distinct_domain_names" {
-  description = "List of distinct domains names used for the validation."
-  value       = module.acm.distinct_domain_names
-}
-
-output "validation_domains" {
-  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
-  value       = module.acm.validation_domains
-}

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,3 @@
-locals {
-  // Get distinct list of domains and SANs
-  distinct_domain_names = distinct(concat([var.domain_name], data.template_file.breakup_san.*.rendered))
-
-  // Copy domain_validation_options for the distinct domain names
-  validation_domains = [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)]
-}
-
-data "template_file" "breakup_san" {
-  count = length(var.subject_alternative_names)
-
-  template = replace(var.subject_alternative_names[count.index], "*.", "")
-}
-
 resource "aws_acm_certificate" "this" {
   count = var.create_certificate ? 1 : 0
 
@@ -27,15 +13,15 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
-  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(var.subject_alternative_names) + 1 : 0
 
   zone_id = var.zone_id
-  name    = element(local.validation_domains, count.index)["resource_record_name"]
-  type    = element(local.validation_domains, count.index)["resource_record_type"]
+  name    = aws_acm_certificate.this[0].domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.this[0].domain_validation_options[count.index]["resource_record_type"]
   ttl     = 60
 
   records = [
-    element(local.validation_domains, count.index)["resource_record_value"]
+    aws_acm_certificate.this[0].domain_validation_options[count.index]["resource_record_value"]
   ]
 
   allow_overwrite = var.validation_allow_overwrite_records

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,13 +17,3 @@ output "validation_route53_record_fqdns" {
   description = "List of FQDNs built using the zone domain and name."
   value       = aws_route53_record.validation.*.fqdn
 }
-
-output "distinct_domain_names" {
-  description = "List of distinct domains names used for the validation."
-  value       = local.distinct_domain_names
-}
-
-output "validation_domains" {
-  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
-  value       = local.validation_domains
-}


### PR DESCRIPTION
# Description

Fixing #10 - Removed domain verification enforcement

Reason being: unnecessary and restrictive filtering in the SAN and domain_name, causing terraform to fail and augmenting complexity in the code. 


