### PR TITLE
Add certificate transparency log option to ACM

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ module "acm" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| certificate\_transparency\_logging\_preference | Specifies whether certificate details should be added to a certificate transparency log | bool | `"false"` | no |
 | create\_certificate | Whether to create ACM certificate | bool | `"true"` | no |
 | domain\_name | A domain name for which the certificate should be issued | string | `""` | no |
 | subject\_alternative\_names | A list of domains that should be SANs in the issued certificate | list(string) | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,10 @@ resource "aws_acm_certificate" "this" {
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
   validation_method         = var.validation_method
+  options = {
+    certificate_transparency_logging_preference = var.certificate_transparency_logging_preference ? "ENABLED" : "DISABLED"
+  }
+
 
   tags = var.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "wait_for_validation" {
   default     = true
 }
 
+variable "certificate_transparency_logging_preference" {
+  description = "Specifies whether certificate details should be added to a certificate transparency log"
+  type        = bool
+  default     = false
+}
+
 variable "domain_name" {
   description = "A domain name for which the certificate should be issued"
   type        = string


### PR DESCRIPTION
# Description

Add certificate transparency log option to ACM
per:
https://www.terraform.io/docs/providers/aws/r/acm_certificate.html#certificate_transparency_logging_preference
https://docs.aws.amazon.com/acm/latest/userguide/acm-concepts.html#concept-transparency