### PR TITLE
Define local.validation_domains properly.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
 
   // Copy domain_validation_options for the distinct domain names
-  validation_domains = [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)]
+  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)] : []
 }
 
 resource "aws_acm_certificate" "this" {


### PR DESCRIPTION
# Description

We came across this bug when upgrading to Terraform 0.12.

We use a pre-created ACM cert when using the `terraform-aws-modules/atlantis/aws` module.  During `terraform plan`, we got this error:

```
Error: Invalid index

  on .terraform/modules/atlantis.acm/terraform-aws-modules-terraform-aws-acm-566067c/main.tf line 6, in locals:
   6:   validation_domains = [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)]
    |----------------
    | aws_acm_certificate.this is empty tuple

The given key does not identify an element in this collection value.

```

This appears to be caused by resource count being zero for `aws_acm_certificate.this`, and thus `aws_acm_certificate.this[0]` is an invalid reference.

This PR fix this by setting `local.validation_domains` to an empty list when `var.create_certificate` is false.