### PR TITLE
Corrected typo for var.domain_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
 
   // Copy domain_validation_options for the distinct domain names
-  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, v.domain_name)] : []
+  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, var.domain_name)] : []
 }
 
 resource "aws_acm_certificate" "this" {


### PR DESCRIPTION
# Description

I think that typo for the var.domain_name returns to the contains function always false. As a result the `local.validation_domains` is always empty and that fails the element functions.

It happens for me on terraform 0.12.16 with the following config:
```
module "certificate" {
  source  = "terraform-aws-modules/acm/aws"
  version = "~> v2.0"

  domain_name = "site.${aws_route53_zone.main.name}"
  zone_id     = aws_route53_zone.main.id
}
```
The error is this:
```
Error: Error in function call

  on .terraform/modules/certificate/terraform-aws-modules-terraform-aws-acm-963ff73/main.tf line 27, in resource "aws_route53_record" "validation":
  27:   name    = element(local.validation_domains, count.index)["resource_record_name"]
    |----------------
    | count.index is 0
    | local.validation_domains is empty tuple

Call to function "element" failed: cannot use element function with an empty
list.


Error: Error in function call

  on .terraform/modules/certificate/terraform-aws-modules-terraform-aws-acm-963ff73/main.tf line 28, in resource "aws_route53_record" "validation":
  28:   type    = element(local.validation_domains, count.index)["resource_record_type"]
    |----------------
    | count.index is 0
    | local.validation_domains is empty tuple

Call to function "element" failed: cannot use element function with an empty
list.


Error: Error in function call

  on .terraform/modules/certificate/terraform-aws-modules-terraform-aws-acm-963ff73/main.tf line 32, in resource "aws_route53_record" "validation":
  32:     element(local.validation_domains, count.index)["resource_record_value"]
    |----------------
    | count.index is 0
    | local.validation_domains is empty tuple

Call to function "element" failed: cannot use element function with an empty
list.
```