### PR TITLE
Feat: Define dns ttl as variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_route53_record" "validation" {
   zone_id = var.zone_id
   name    = element(local.validation_domains, count.index)["resource_record_name"]
   type    = element(local.validation_domains, count.index)["resource_record_type"]
-  ttl     = 60
+  ttl     = var.dns_ttl
 
   records = [
     element(local.validation_domains, count.index)["resource_record_value"]

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "dns_ttl" {
+  description = "The TTL of DNS recursive resolvers to cache information about this record."
+  type        = string
+  default     = "60"
+}


### PR DESCRIPTION
# The current TTL is hardcode

Setting the  TTL as a variable will keep more flexible in a case to a short DNS TTL or long.