### PR TITLE
fix: Fix an off-by-one error with validation records

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
-  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) + 1 : 0
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
   zone_id = var.zone_id
   name    = element(local.validation_domains, count.index)["resource_record_name"]


### PR DESCRIPTION
## Description

Prevent duplicated validation record causing failures when `validation_allow_overwrite_records` is set to `false`.

## Motivation and Context

PR #32 introduces an obscure off-by-one error that leads to a duplicated validation record because of a wrap-around in `distinct_domain_names`.

I assume this hasn't been spotted until now mainly because the duplicated record gets silently overwritten when `validation_allow_overwrite_records` is set to `true` (as it is by
default).

I tried to identify corner cases when this `+ 1` is required, but couldn't find any. Please let me know if you are aware why it may be needed.

## Breaking Changes

I don't think this is breaking backwards compatibility.

## How Has This Been Tested?

Used latest `master` with disabled `validation_allow_overwrite_records` in `examples/complete-dns-validation` and verified that Terraform fails to apply.

Then did the change in this PR and managed to apply successfully.