### PR TITLE
breaking: Allow for route53 and ACM to use different providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,21 +62,36 @@ module "acm" {
 
 * For use in an automated pipeline consider setting the `wait_for_validation = false` to avoid waiting for validation to complete or error after a 45 minute timeout.
 * `domain_name` can not be wildcard, but `subject_alternative_names` can include wildcards.
+* This module allows to use multiple providers. This feature brings the module the ability to be used in an AWS  multi-account environment but bring the caveat of forcing its user to explicitly declare the provider to use.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.24.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws.acm | >= 2.24.0 |
+| aws.dns | >= 2.24.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| create\_certificate | Whether to create ACM certificate | bool | `"true"` | no |
-| domain\_name | A domain name for which the certificate should be issued | string | `""` | no |
-| subject\_alternative\_names | A list of domains that should be SANs in the issued certificate | list(string) | `[]` | no |
-| tags | A mapping of tags to assign to the resource | map(string) | `{}` | no |
-| validate\_certificate | Whether to validate certificate by creating Route53 record | bool | `"true"` | no |
-| validation\_allow\_overwrite\_records | Whether to allow overwrite of Route53 records | bool | `"true"` | no |
-| validation\_method | Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform. | string | `"DNS"` | no |
-| wait\_for\_validation | Whether to wait for the validation to complete | bool | `"true"` | no |
-| zone\_id | The ID of the hosted zone to contain this record. | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| create\_certificate | Whether to create ACM certificate | `bool` | `true` | no |
+| domain\_name | A domain name for which the certificate should be issued | `string` | `""` | no |
+| subject\_alternative\_names | A list of domains that should be SANs in the issued certificate | `list(string)` | `[]` | no |
+| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| validate\_certificate | Whether to validate certificate by creating Route53 record | `bool` | `true` | no |
+| validation\_allow\_overwrite\_records | Whether to allow overwrite of Route53 records | `bool` | `true` | no |
+| validation\_method | Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform. | `string` | `"DNS"` | no |
+| wait\_for\_validation | Whether to wait for the validation to complete | `bool` | `true` | no |
+| zone\_id | The ID of the hosted zone to contain this record. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/complete-dns-validation/README.md
+++ b/examples/complete-dns-validation/README.md
@@ -19,6 +19,20 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -23,6 +23,11 @@ resource "aws_route53_zone" "this" {
 module "acm" {
   source = "../../"
 
+  providers = {
+    aws.dns = aws
+    aws.acm = aws
+  }
+
   domain_name = local.domain_name
   zone_id     = coalescelist(data.aws_route53_zone.this.*.zone_id, aws_route53_zone.this.*.zone_id)[0]
 

--- a/examples/complete-email-validation/README.md
+++ b/examples/complete-email-validation/README.md
@@ -32,11 +32,21 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| domain\_name | Domain name to use as Route53 zone and ACM certificate | string | `"my-domain-name2.com"` | no |
+|------|-------------|------|---------|:--------:|
+| domain\_name | Domain name to use as Route53 zone and ACM certificate | `string` | `"my-domain-name2.com"` | no |
 
 ## Outputs
 

--- a/examples/complete-email-validation/main.tf
+++ b/examples/complete-email-validation/main.tf
@@ -1,3 +1,9 @@
+provider "aws" {}
+
+provider "aws" {
+  alias = "dns"
+}
+
 variable "domain_name" {
   description = "Domain name to use as Route53 zone and ACM certificate"
   default     = "my-domain-name2.com"
@@ -9,6 +15,11 @@ resource "aws_route53_zone" "this" {
 
 module "acm" {
   source = "../../"
+
+  providers = {
+    aws.dns = aws.dns
+    aws.acm = aws
+  }
 
   domain_name = var.domain_name
   zone_id     = aws_route53_zone.this.zone_id

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,11 @@
+provider "aws" {
+  alias = "acm"
+}
+
+provider "aws" {
+  alias = "dns"
+}
+
 locals {
   // Get distinct list of domains and SANs
   distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
@@ -8,6 +16,8 @@ locals {
 
 resource "aws_acm_certificate" "this" {
   count = var.create_certificate ? 1 : 0
+
+  provider = aws.acm
 
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
@@ -22,6 +32,8 @@ resource "aws_acm_certificate" "this" {
 
 resource "aws_route53_record" "validation" {
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) + 1 : 0
+
+  provider = aws.dns
 
   zone_id = var.zone_id
   name    = element(local.validation_domains, count.index)["resource_record_name"]
@@ -39,6 +51,8 @@ resource "aws_route53_record" "validation" {
 
 resource "aws_acm_certificate_validation" "this" {
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0
+
+  provider = aws.acm
 
   certificate_arn = aws_acm_certificate.this[0].arn
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.24.0"
+  }
+}
+


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow for route53 and ACM to use different providers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In a context of multiple AWS accounts, a common pattern is to centralize
all DNS entries into a single sepearate account. This changes allows
usage of this module in that particular scenario.

The main caveat of this functionnality is that it forces setting the
providers upon module usage. Which is not ideal, but I don't see that as
a complex adjustment as well.

I will understand if you refuse the pull request because of the caveat. But it does allow more flexibility and I prefer not have to maintain forks on the long run.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Yes, it will force users to explicitly pass the providers to the module

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's currently used internally.
