### PR TITLE
Prevent certificate recreation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   // Get distinct list of domains and SANs
-  distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
+  distinct_domain_names = sort(distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")])))
 
   // Copy domain_validation_options for the distinct domain names
   validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []


### PR DESCRIPTION
## Description

it seems the API returns the values in random order.

```diff
      ~ subject_alternative_names = [ # forces replacement
          - "*.example.net",
          - "*.prod.example.com",
            "*.prod-eu-west-1.example.com",
          + "*.example.com",
          + "*.prod.example.net",
        ]
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes

it might force recreation of the certificate for the last time.

## How Has This Been Tested?
yes

```
Terraform v0.12.26
+ provider.aws v2.66.0
+ provider.kubernetes v1.11.3
+ provider.local v1.4.0
+ provider.null v2.1.2
+ provider.random v2.1.0
```