### PR TITLE
fix: Wait for correct certificate_arn when validation is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,9 +4,6 @@ locals {
 
   // Copy domain_validation_options for the distinct domain names
   validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
-
-  // This variable tells us if it needs to validate or not
-  should_wait_for_validation = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? true : false
 }
 
 resource "aws_acm_certificate" "this" {
@@ -45,7 +42,7 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count =  local.should_wait_for_validation ? 1 : 0
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0
 
   certificate_arn = aws_acm_certificate.this[0].arn
 

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,9 @@ locals {
 
   // Copy domain_validation_options for the distinct domain names
   validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
+
+  // This variable tells us if it needs to validate or not
+  should_wait_for_validation = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? true : false
 }
 
 resource "aws_acm_certificate" "this" {
@@ -42,7 +45,7 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate && var.wait_for_validation ? 1 : 0
+  count =  local.should_wait_for_validation ? 1 : 0
 
   certificate_arn = aws_acm_certificate.this[0].arn
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "this_acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value =  local.should_wait_for_validation ? element(concat(aws_acm_certificate_validation.this.*.certificate_arn, [""]), 0) : element(concat(aws_acm_certificate.this.*.arn, [""]), 0)
+  value       = element(concat(aws_acm_certificate_validation.this.*.certificate_arn, aws_acm_certificate.this.*.arn, [""]), 0)
 }
 
 output "this_acm_certificate_domain_validation_options" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "this_acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value       = element(concat(aws_acm_certificate.this.*.arn, [""]), 0)
+  value =  local.should_wait_for_validation ? element(concat(aws_acm_certificate_validation.this.*.certificate_arn, [""]), 0) : element(concat(aws_acm_certificate.this.*.arn, [""]), 0)
 }
 
 output "this_acm_certificate_domain_validation_options" {


### PR DESCRIPTION
## Description
I'm adding a way to wait for the DNS cert validation to be complete

## Motivation and Context
There is no good way to wait until the certificate is validated, so there is a race condition when trying to use the certificate.
This allows you to wait for it.

A use example would be:
```
resource "aws_lb_listener" "front_end" {
  # [...]
  certificate_arn = "${module.acm.validated_acm_certificate_ar}"
}
```
## Breaking Changes
No breaking changes

## How Has This Been Tested?
I tried using the certificate on an aws_lb_listener. 
Before: Needed 2 applies (first one ends up with error)
After: One apply and everything working

Also, tried using it in an already created cert. It worked.