### PR TITLE
fix: creation of route53 validation records when the main domain name starts with star

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   // Get distinct list of domains and SANs
-  distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
+  distinct_domain_names = distinct(concat([replace(var.domain_name, "*.", "")], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
 
   // Copy domain_validation_options for the distinct domain names
   validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []


### PR DESCRIPTION
## Description

Consider an example where we use star (*) as prefix for `domain_name`:

```
module "example" {
  source  = "terraform-aws-modules/acm/aws"
  version = "~> v2.0"

  domain_name  = "*.api.example.com"
  zone_id      = aws_route53_zone.main.zone_id
}
```

This should work correctly but it fails building the validation records for route 53.
The reason why is a piece of code on `locals`:

```
locals {
  // Get distinct list of domains and SANs
  distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))

  // Copy domain_validation_options for the distinct domain names
  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
}
```

The problem here is that `domain_name` has a star but when comparing it on the `validation_domains` for-loop the star is removed there on comparison and they will never match.

A simple fix is to consider domain name can also have star and strip it like done on this PR.

## Breaking Changes

No breaking changes.

## How Has This Been Tested?

I have run the example above after doing the fix and it worked.

## Workaround while this is not fixed

To workaround I have setup it like this:

```
module "example" {
  source  = "terraform-aws-modules/acm/aws"
  version = "~> v2.0"

  domain_name  = "api.example.com"
  zone_id      = aws_route53_zone.main.zone_id

  subject_alternative_names = [
    "*.api.example.com"
  ]
}
```
