### PR TITLE
feat: use hosted zone from another AWS account

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ module "acm" {
   tags = {
     Name = "my-domain.com"
   }
+
+  providers = {
+    aws = aws
+    # use different aws provider
+    # if hosted zone is in another aws account
+    aws.route53 = aws
+  }
 }
 ```
 
@@ -33,6 +40,49 @@ module "acm" {
 
 * [Complete example with DNS validation (recommended)](https://github.com/terraform-aws-modules/terraform-aws-acm/tree/master/examples/complete-dns-validation)
 * [Complete example with EMAIL validation](https://github.com/terraform-aws-modules/terraform-aws-acm/tree/master/examples/complete-email-validation)
+
+## hosted zone in another AWS account
+
+In certain scenarios if hosted zone is present in another AWS account, then we can pass the a different aws provider to the module.
+
+### hosted zone in same account
+
+```hcl
+module "acm" {
+  source  = "terraform-aws-modules/acm/aws"
+  version = "~> v2.0"
+
+  # ... omitted
+
+  providers = {
+    aws = aws
+    aws.route53 = aws
+  }
+```
+
+### hosted zone in different account
+
+```hcl
+provider "aws" {
+  # ... omitted
+}
+
+provider "aws" {
+  alias = "production"
+  # ... omitted
+}
+
+module "acm" {
+  source  = "terraform-aws-modules/acm/aws"
+  version = "~> v2.0"
+
+  # ... omitted
+
+  providers = {
+    aws = aws
+    aws.route53 = aws.production
+  }
+```
 
 ## Conditional creation and validation
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ module "acm" {
 
   providers = {
     aws = aws
-    # use different aws provider
-    # if hosted zone is in another aws account
+    # hosted zone in same account
     aws.route53 = aws
   }
 }
@@ -80,6 +79,7 @@ module "acm" {
 
   providers = {
     aws = aws
+    # hosted zone in production account
     aws.route53 = aws.production
   }
 ```

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -46,8 +46,7 @@ module "acm" {
 
   providers = {
     aws = aws
-    # use different aws provider
-    # if hosted zone is in another aws account
+    # hosted zone in same account
     aws.route53 = aws
   }
 }

--- a/examples/complete-email-validation/main.tf
+++ b/examples/complete-email-validation/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
 variable "domain_name" {
   description = "Domain name to use as Route53 zone and ACM certificate"
   default     = "my-domain-name2.com"
@@ -21,5 +25,12 @@ module "acm" {
 
   tags = {
     Name = var.domain_name
+  }
+
+  providers = {
+    aws = aws
+    # use different aws provider
+    # if hosted zone is in another aws account
+    aws.route53 = aws
   }
 }

--- a/examples/complete-email-validation/main.tf
+++ b/examples/complete-email-validation/main.tf
@@ -29,8 +29,7 @@ module "acm" {
 
   providers = {
     aws = aws
-    # use different aws provider
-    # if hosted zone is in another aws account
+    # hosted zone in same account
     aws.route53 = aws
   }
 }

--- a/examples/complete-hosted-zone-in-diff-aws/README.md
+++ b/examples/complete-hosted-zone-in-diff-aws/README.md
@@ -1,12 +1,18 @@
 # Complete ACM example with Route53 DNS validation in another AWS account
 
-Configuration in this directory creates new Route53 zone in another AWS account with provided credentials and ACM certificate (valid for the domain name and wildcard) in current account.
+Configuration in this directory creates new / use existing Route53 zone in `production`(another) AWS account with provided credentials and ACM certificate (valid for the domain name and wildcard) in `development` aws account.
 
 Also, ACM certificate is being validate using DNS method.
 
-This is a complete example which fits most of scenarios.
-
 ## Usage
+
+Make sure you have correct `aws` credentials set using profiles `development` and `production`.
+
+Where,
+development - `aws` account where ACM certificate needs to be created
+production  - `aws` account where Route 53 zone exists / need to be created for DNS validation.
+
+> Note: As per the use case, `aws` provider can be updated to use [assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assume-role) for `production` account in `provider` configuration.
 
 To run this example you need to execute:
 

--- a/examples/complete-hosted-zone-in-diff-aws/README.md
+++ b/examples/complete-hosted-zone-in-diff-aws/README.md
@@ -1,0 +1,47 @@
+# Complete ACM example with Route53 DNS validation in another AWS account
+
+Configuration in this directory creates new Route53 zone in another AWS account with provided credentials and ACM certificate (valid for the domain name and wildcard) in current account.
+
+Also, ACM certificate is being validate using DNS method.
+
+This is a complete example which fits most of scenarios.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+No input.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| distinct\_domain\_names | List of distinct domains names used for the validation. |
+| this\_acm\_certificate\_arn | The ARN of the certificate |
+| this\_acm\_certificate\_domain\_validation\_options | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| this\_acm\_certificate\_validation\_emails | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
+| validation\_domains | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |
+| validation\_route53\_record\_fqdns | List of FQDNs built using the zone domain and name. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-hosted-zone-in-diff-aws/main.tf
+++ b/examples/complete-hosted-zone-in-diff-aws/main.tf
@@ -1,17 +1,19 @@
 provider "aws" {
   region = "us-east-1"
+  profile = "development"
 }
 
 # this is where hosted zone present/need to be created
 provider "aws" {
   region = "us-east-1"
   alias  = "production"
+  profile = "production"
 }
 
 
 locals {
   # Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)
-  use_existing_route53_zone = true
+  use_existing_route53_zone = false
 
   domain = "terraform-aws-modules.modules.tf"
 
@@ -42,11 +44,8 @@ module "acm" {
   zone_id     = coalescelist(data.aws_route53_zone.this.*.zone_id, aws_route53_zone.this.*.zone_id)[0]
 
   subject_alternative_names = [
-    "*.alerts.${local.domain_name}",
-    "*.something.${local.domain_name}",
-    "*.news.${local.domain_name}",
-    "*.info.${local.domain_name}",
-    "new.sub.${local.domain_name}",
+    "dev.${local.domain_name}",
+    "*.dev.${local.domain_name}",
   ]
 
   wait_for_validation = true
@@ -57,8 +56,7 @@ module "acm" {
 
   providers = {
     aws = aws
-    # use different aws provider
-    # if hosted zone is in another aws account
+    # hosted zone in production(another) account
     aws.route53 = aws.production
   }
 }

--- a/examples/complete-hosted-zone-in-diff-aws/main.tf
+++ b/examples/complete-hosted-zone-in-diff-aws/main.tf
@@ -2,6 +2,13 @@ provider "aws" {
   region = "us-east-1"
 }
 
+# this is where hosted zone present/need to be created
+provider "aws" {
+  region = "us-east-1"
+  alias  = "production"
+}
+
+
 locals {
   # Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)
   use_existing_route53_zone = true
@@ -13,6 +20,8 @@ locals {
 }
 
 data "aws_route53_zone" "this" {
+  provider = aws.production
+
   count = local.use_existing_route53_zone ? 1 : 0
 
   name         = local.domain_name
@@ -20,6 +29,8 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_zone" "this" {
+  provider = aws.production
+
   count = ! local.use_existing_route53_zone ? 1 : 0
   name  = local.domain_name
 }
@@ -48,6 +59,6 @@ module "acm" {
     aws = aws
     # use different aws provider
     # if hosted zone is in another aws account
-    aws.route53 = aws
+    aws.route53 = aws.production
   }
 }

--- a/examples/complete-hosted-zone-in-diff-aws/outputs.tf
+++ b/examples/complete-hosted-zone-in-diff-aws/outputs.tf
@@ -1,0 +1,29 @@
+output "this_acm_certificate_arn" {
+  description = "The ARN of the certificate"
+  value       = module.acm.this_acm_certificate_arn
+}
+
+output "this_acm_certificate_domain_validation_options" {
+  description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
+  value       = module.acm.this_acm_certificate_domain_validation_options
+}
+
+output "this_acm_certificate_validation_emails" {
+  description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
+  value       = module.acm.this_acm_certificate_validation_emails
+}
+
+output "validation_route53_record_fqdns" {
+  description = "List of FQDNs built using the zone domain and name."
+  value       = module.acm.validation_route53_record_fqdns
+}
+
+output "distinct_domain_names" {
+  description = "List of distinct domains names used for the validation."
+  value       = module.acm.distinct_domain_names
+}
+
+output "validation_domains" {
+  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
+  value       = module.acm.validation_domains
+}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+// This provider should be used for route 53 resources where hosted zone exits
+provider "aws" {
+  alias = "route53"
+}
+
 locals {
   // Get distinct list of domains and SANs
   distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
@@ -25,6 +30,8 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
+  provider = aws.route53
+
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) + 1 : 0
 
   zone_id = var.zone_id


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Provide a way to create DNS validation record in hosted zone present in another AWS account.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some cases, hosted zone is maintained in a different account (say `production`) and if want to create a ACM certificate in `development` AWS account, then this would come handy.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Yes, this would be a BREAKING CHANGE. As older module code needs to be provided a `provider` with default `aws` provider.

```hcl
module "acm" {
 # ... omitted

  providers = {
    aws = aws
    # hosted zone is in same aws account
    aws.route53 = aws
  }
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
terraform init
terraform validate
terraform plan
```
