### PR TITLE
Sort list items to prevent order changes in domain lists

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_acm_certificate" "this" {
   count = var.create_certificate ? 1 : 0
 
   domain_name               = var.domain_name
-  subject_alternative_names = var.subject_alternative_names
+  subject_alternative_names = sort(var.subject_alternative_names)
   validation_method         = var.validation_method
 
   options {


### PR DESCRIPTION
## Description
Added `sort()` function to sort alternative domain list parameter

## Motivation and Context
Sometimes constructed lists change order of the list items when generated programmatically, which causes ACM cert to be re-requested, creating essentially the same cert with a different order.
This is an attempt to ensure this is not happening

This is merely a safeguard for users, which ensures better default behavior. If the current stance of the module is that a user should take care of it, that's fine too, so feel free to reject it. Thanks!

## Breaking Changes
No breaking changes expected.

## How Has This Been Tested?
Used `sort()` in front of module parameter, when passed to a module.
