### PR TITLE
Fix for #33

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
 
   # Copy domain_validation_options for the distinct domain names
   validation_domains = var.create_certificate ? [for k, v in flatten(aws_acm_certificate.this.*.domain_validation_options) : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
+
 }
 
 resource "aws_acm_certificate" "this" {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
 
   # Copy domain_validation_options for the distinct domain names
-  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
+  validation_domains = var.create_certificate ? [for k, v in flatten(aws_acm_certificate.this.*.domain_validation_options) : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
 }
 
 resource "aws_acm_certificate" "this" {


### PR DESCRIPTION
## Description
in Motivation and Context ⤵

## Motivation and Context
attempt to fix https://github.com/terraform-aws-modules/terraform-aws-acm/issues/33
also mentioned at https://github.com/terraform-aws-modules/terraform-aws-acm/issues/26#issuecomment-600809747


## Breaking Changes
No breaking changes.

## How Has This Been Tested?
Tested on sandbox environment as a part of destroy phase, 
otherwise destroy comes out with: 
```
Error: Invalid index

  on .terraform/modules/test-sonar-ecs-service.ssl-cert/main.tf line 6, in locals:
   6:   validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
    |----------------
    | aws_acm_certificate.this is empty tuple

The given key does not identify an element in this collection value.
```