### PR TITLE
fix: Fixed wildcard in domain names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+.terraform.lock.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module which creates ACM certificates and validates them using Route53
 
 Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
 
-Terraform 0.11. Pin module version to `~> v1.0`. Submit pull-requests to `terraform011` branch.
+Terraform 0.11. Pin module version to `~> v1.0`.
 
 ## Usage with Route53 DNS validation (recommended)
 
@@ -61,7 +61,6 @@ module "acm" {
 ## Notes
 
 * For use in an automated pipeline consider setting the `wait_for_validation = false` to avoid waiting for validation to complete or error after a 45 minute timeout.
-* `domain_name` can not be wildcard, but `subject_alternative_names` can include wildcards.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -76,6 +75,18 @@ module "acm" {
 | Name | Version |
 |------|---------|
 | aws | >= 2.53 |
+
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_acm_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/2.53/docs/resources/acm_certificate_validation) |
+| [aws_acm_certificate](https://registry.terraform.io/providers/hashicorp/aws/2.53/docs/resources/acm_certificate) |
+| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/2.53/docs/resources/route53_record) |
 
 ## Inputs
 
@@ -103,7 +114,6 @@ module "acm" {
 | this\_acm\_certificate\_validation\_emails | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
 | validation\_domains | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |
 | validation\_route53\_record\_fqdns | List of FQDNs built using the zone domain and name. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete-dns-validation/README.md
+++ b/examples/complete-dns-validation/README.md
@@ -32,6 +32,19 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.53 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| acm | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.53/docs/data-sources/route53_zone) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.53/docs/resources/route53_zone) |
+
 ## Inputs
 
 No input.
@@ -46,5 +59,4 @@ No input.
 | this\_acm\_certificate\_validation\_emails | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
 | validation\_domains | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |
 | validation\_route53\_record\_fqdns | List of FQDNs built using the zone domain and name. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -16,7 +16,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_zone" "this" {
-  count = ! local.use_existing_route53_zone ? 1 : 0
+  count = !local.use_existing_route53_zone ? 1 : 0
   name  = local.domain_name
 }
 
@@ -28,10 +28,8 @@ module "acm" {
 
   subject_alternative_names = [
     "*.alerts.${local.domain_name}",
-    "*.something.${local.domain_name}",
-    "*.news.${local.domain_name}",
-    "*.info.${local.domain_name}",
     "new.sub.${local.domain_name}",
+    "*.${local.domain_name}",
   ]
 
   wait_for_validation = true

--- a/examples/complete-email-validation/README.md
+++ b/examples/complete-email-validation/README.md
@@ -45,6 +45,18 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|---------|
 | aws | >= 2.53 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| acm | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/2.53/docs/resources/route53_zone) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -58,5 +70,4 @@ Note that this example may create resources which cost money. Run `terraform des
 | this\_acm\_certificate\_arn | The ARN of the certificate |
 | this\_acm\_certificate\_domain\_validation\_options | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
 | this\_acm\_certificate\_validation\_emails | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 locals {
   # Get distinct list of domains and SANs
-  distinct_domain_names = distinct(concat([var.domain_name], [for s in var.subject_alternative_names : replace(s, "*.", "")]))
+  distinct_domain_names = distinct(
+    [for s in concat([var.domain_name], var.subject_alternative_names) : replace(s, "*.", "")]
+  )
 
   # Copy domain_validation_options for the distinct domain names
   validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
@@ -25,7 +27,7 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
-  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) + 1 : 0
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
   zone_id = var.zone_id
   name    = element(local.validation_domains, count.index)["resource_record_name"]


### PR DESCRIPTION
### Wildcard in domain names:

Fixes #57
Fixes #67

```
module "example" {
  source  = "terraform-aws-modules/acm/aws"
  version = "~> v2.0"

  domain_name  = "*.api.example.com"
  zone_id      = aws_route53_zone.main.zone_id
}
```

### 

Resolves #15
Resolves #47

Closes #64

Relates to #33 (Fixes #70)