### PR TITLE
fix: bump min supported version due to types unsupported on current

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module "acm" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.53 |
 
 ## Providers

--- a/examples/complete-dns-validation/README.md
+++ b/examples/complete-dns-validation/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.53 |
 
 ## Providers

--- a/examples/complete-dns-validation/versions.tf
+++ b/examples/complete-dns-validation/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.53"

--- a/examples/complete-email-validation/README.md
+++ b/examples/complete-email-validation/README.md
@@ -36,7 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.53 |
 
 ## Providers

--- a/examples/complete-email-validation/versions.tf
+++ b/examples/complete-email-validation/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.53"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.53"


### PR DESCRIPTION
## Description
- bump min supported version due to types unsupported on current

## Motivation and Context
- get static checks back to passing state

## Breaking Changes
- no

## How Has This Been Tested?
- ci-cd static checks