### PR TITLE
Update versions.tf for Terraform 0.13.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = ">= 2.53"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.53"
+    }
   }
 }


### PR DESCRIPTION
## Description
Upgrade versions.tf file to be compatible with Terraform 0.13+.

## Motivation and Context
Personally, I had another module which forced the issue of upgrading past 0.12.x.  Others
are likely to run into this increasingly as community modules upgrade from 0.12 to 0.13 or 0.14.

## Breaking Changes
I believe this will be a breaking change to Terraform 0.12 users and may be best to put behind a
major version release on the module.

## How Has This Been Tested?
Yes, my personal AWS setup is now using my fork of your repo and it works fine with Terraform
0.14.9.
