### PR TITLE
feat: retrieve the zone ids dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ module "acm" {
   version = "~> v3.0"
 
   domain_name  = "my-domain.com"
-  zone_id      = "Z2ES7B9AZ6SHAE"
 
   subject_alternative_names = [
     "*.my-domain.com",
@@ -99,7 +98,6 @@ No modules.
 | <a name="input_validation_allow_overwrite_records"></a> [validation\_allow\_overwrite\_records](#input\_validation\_allow\_overwrite\_records) | Whether to allow overwrite of Route53 records | `bool` | `true` | no |
 | <a name="input_validation_method"></a> [validation\_method](#input\_validation\_method) | Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform. | `string` | `"DNS"` | no |
 | <a name="input_wait_for_validation"></a> [wait\_for\_validation](#input\_wait\_for\_validation) | Whether to wait for the validation to complete | `bool` | `true` | no |
-| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | The ID of the hosted zone to contain this record. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -16,7 +16,7 @@ data "aws_route53_zone" "this" {
 }
 
 resource "aws_route53_zone" "this" {
-  count = !local.use_existing_route53_zone ? 1 : 0
+  count = ! local.use_existing_route53_zone ? 1 : 0
   name  = local.domain_name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,12 +46,6 @@ variable "validation_method" {
   default     = "DNS"
 }
 
-variable "zone_id" {
-  description = "The ID of the hosted zone to contain this record."
-  type        = string
-  default     = ""
-}
-
 variable "tags" {
   description = "A mapping of tags to assign to the resource"
   type        = map(string)


### PR DESCRIPTION
## Description
Retrive the root domain Zone ID dynamically

## Motivation and Context
Helpful when you have an SSL Cert with varius `subject alternative names`

```hcl
domain_name = "*.abc.com"
subject_alternative_names = [
    "*.abc.cloud",
    "*.xyz.com",
  ]
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I have tested the proposed changes in my private project using multiple domains.