### PR TITLE
fix: create missing validation records in cases (eg, wildcard SAN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module which creates ACM certificates and validates them using Route53
 ```hcl
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "~> v3.0"
+  version = "~> 3.0"
 
   domain_name  = "my-domain.com"
   zone_id      = "Z2ES7B9AZ6SHAE"

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -30,6 +30,7 @@ module "acm" {
     "*.alerts.${local.domain_name}",
     "new.sub.${local.domain_name}",
     "*.${local.domain_name}",
+    "alerts.${local.domain_name}",
   ]
 
   wait_for_validation = true

--- a/main.tf
+++ b/main.tf
@@ -4,16 +4,12 @@ locals {
     [for s in concat([var.domain_name], var.subject_alternative_names) : replace(s, "*.", "")]
   )
 
-  # Copy domain_validation_options for the distinct domain names
-  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
-
   # Get the list of distinct domain_validation_options, with wildcard
   # domain names replaced by the domain name
-  distinct_validation_domains = var.create_certificate ? distinct(
-    [for v in local.validation_domains : merge(
-        tomap(v),
-        { domain_name = replace(v.domain_name, "*.", "") }
-      )
+  validation_domains = var.create_certificate ? distinct(
+    [for k, v in aws_acm_certificate.this[0].domain_validation_options : merge(
+      tomap(v), { domain_name = replace(v.domain_name, "*.", "") }
+    )]
   ) : []
 }
 
@@ -39,12 +35,12 @@ resource "aws_route53_record" "validation" {
   count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
   zone_id = var.zone_id
-  name    = element(local.distinct_validation_domains, count.index)["resource_record_name"]
-  type    = element(local.distinct_validation_domains, count.index)["resource_record_type"]
+  name    = element(local.validation_domains, count.index)["resource_record_name"]
+  type    = element(local.validation_domains, count.index)["resource_record_type"]
   ttl     = var.dns_ttl
 
   records = [
-    element(local.distinct_validation_domains, count.index)["resource_record_value"]
+    element(local.validation_domains, count.index)["resource_record_value"]
   ]
 
   allow_overwrite = var.validation_allow_overwrite_records

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,12 @@ locals {
   )
 
   # Copy domain_validation_options for the distinct domain names
-  validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
+  validation_domains = var.create_certificate ? distinct(
+    [for v in aws_acm_certificate.this[0].domain_validation_options : merge(
+        tomap(v),
+        { domain_name = replace(v.domain_name, "*.", "") }
+      ) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))]
+  ) : []
 }
 
 resource "aws_acm_certificate" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,5 +25,5 @@ output "distinct_domain_names" {
 
 output "validation_domains" {
   description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
-  value       = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
+  value       = local.validation_domains
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,5 +25,5 @@ output "distinct_domain_names" {
 
 output "validation_domains" {
   description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
-  value       = local.validation_domains
+  value       = var.create_certificate ? [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))] : []
 }


### PR DESCRIPTION
## Description

Make sure that a single validation record is created for both `*.domain` and `domain` items from `aws_acm_certificate.this[0].domain_validation_options`.

## Motivation and Context

Fixes #82

When wildcard SANs are used, the module may not create all the necessary validation records.

## Breaking Changes

It may affect the users, if any, who have created a certificate that is not yet validated because of the missing validation records. Running `terraform apply` may delete one or more existing validation records due to the recomputed `validation_domains` list. Running `apply` one more time will be necessary to create again the validation records deleted by the previous `apply`.

## How Has This Been Tested?

Using the example from the #82 `terraform console` output.