### PR TITLE
feat: certificate validation with multiple Route 53 zones

### DIFF
--- a/examples/complete-dns-validation/outputs.tf
+++ b/examples/complete-dns-validation/outputs.tf
@@ -19,11 +19,11 @@ output "validation_route53_record_fqdns" {
 }
 
 output "distinct_domain_names" {
-  description = "List of distinct domains names used for the validation."
+  description = "List of distinct domains names used for validation. It does not include the certificate distinct domain names that were not mapped to a hosted zone."
   value       = module.acm.distinct_domain_names
 }
 
 output "validation_domains" {
-  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
+  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards. It does not include the domain validation options for the certificate distinct domain names that were not mapped to a hosted zone."
   value       = module.acm.validation_domains
 }

--- a/examples/multiple-zones-dns-validation/README.md
+++ b/examples/multiple-zones-dns-validation/README.md
@@ -1,0 +1,60 @@
+# ACM example with multiple Route53 DNS validation
+
+Configuration in this directory creates three Route53 zones (one of them delegates a subdomain to another zone from the set) and one ACM certificate (valid for the three domain names, their wildcards and various example subdomains of them).
+
+Also, ACM certificate is being validate using DNS method.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.53 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.53 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acm"></a> [acm](#module\_acm) | ../../ |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | The ARN of the certificate |
+| <a name="output_acm_certificate_domain_validation_options"></a> [acm\_certificate\_domain\_validation\_options](#output\_acm\_certificate\_domain\_validation\_options) | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| <a name="output_acm_certificate_validation_emails"></a> [acm\_certificate\_validation\_emails](#output\_acm\_certificate\_validation\_emails) | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
+| <a name="output_distinct_domain_names"></a> [distinct\_domain\_names](#output\_distinct\_domain\_names) | List of distinct domains names used for the validation. |
+| <a name="output_validation_domains"></a> [validation\_domains](#output\_validation\_domains) | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |
+| <a name="output_validation_route53_record_fqdns"></a> [validation\_route53\_record\_fqdns](#output\_validation\_route53\_record\_fqdns) | List of FQDNs built using the zone domain and name. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple-zones-dns-validation/README.md
+++ b/examples/multiple-zones-dns-validation/README.md
@@ -40,6 +40,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 

--- a/examples/multiple-zones-dns-validation/README.md
+++ b/examples/multiple-zones-dns-validation/README.md
@@ -40,7 +40,6 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
-| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 

--- a/examples/multiple-zones-dns-validation/main.tf
+++ b/examples/multiple-zones-dns-validation/main.tf
@@ -2,14 +2,18 @@ locals {
   # Use existing (via data source) or create new zones (will fail validation, if zone is not reachable)
   use_existing_route53_zones = true
 
-  domain = "terraform-aws-modules.modules.tf"
-  alternate_domain = "terraform-aws-modules.modules-alt.tf"
+  domain              = "terraform-aws-modules.modules.tf"
+  alternate_domain    = "terraform-aws-modules.modules-alt.tf"
   alternate_subdomain = "sub.${local.alternate_domain}"
 
   # Removing trailing dot from domains - just to be sure :)
-  domain_name = trimsuffix(local.domain, ".")
-  alternate_domain_name = trimsuffix(local.alternate_domain, ".")
+  domain_name              = trimsuffix(local.domain, ".")
+  alternate_domain_name    = trimsuffix(local.alternate_domain, ".")
   alternate_subdomain_name = trimsuffix(local.alternate_subdomain, ".")
+
+  domain_zone_id              = coalescelist(data.aws_route53_zone.domain.*.zone_id, aws_route53_zone.domain.*.zone_id)[0]
+  alternate_domain_zone_id    = coalescelist(data.aws_route53_zone.alternate_domain.*.zone_id, aws_route53_zone.alternate_domain.*.zone_id)[0]
+  alternate_subdomain_zone_id = coalescelist(data.aws_route53_zone.alternate_subdomain.*.zone_id, aws_route53_zone.alternate_subdomain.*.zone_id)[0]
 }
 
 data "aws_route53_zone" "domain" {
@@ -69,21 +73,19 @@ module "acm" {
     "alerts.${local.domain_name}",
     local.alternate_domain_name,
     "*.${local.alternate_domain_name}",
-    "quite.deep.abc.sub.${local.alternate_domain_name}",
+    "quite.deep.abc.${local.alternate_subdomain_name}",
     "def.${local.alternate_subdomain_name}",
     "*.${local.alternate_subdomain_name}",
   ]
 
   domain_zones = {
-    (local.domain_name) = {
-      zone_id = coalescelist(data.aws_route53_zone.domain.*.zone_id, aws_route53_zone.domain.*.zone_id)[0]
-    }
-    (local.alternate_domain_name) = {
-      zone_id = coalescelist(data.aws_route53_zone.alternate_domain.*.zone_id, aws_route53_zone.alternate_domain.*.zone_id)[0]
-    }
-    (local.alternate_subdomain_name) = {
-      zone_id = coalescelist(data.aws_route53_zone.alternate_subdomain.*.zone_id, aws_route53_zone.alternate_subdomain.*.zone_id)[0]
-    }
+    (local.domain_name)                                = { zone_id = local.domain_zone_id }
+    "alerts.${local.domain_name}"                      = { zone_id = local.domain_zone_id }
+    "new.sub.${local.domain_name}"                     = { zone_id = local.domain_zone_id }
+    (local.alternate_domain_name)                      = { zone_id = local.alternate_domain_zone_id }
+    (local.alternate_subdomain_name)                   = { zone_id = local.alternate_subdomain_zone_id }
+    "def.${local.alternate_subdomain_name}"            = { zone_id = local.alternate_subdomain_zone_id }
+    "quite.deep.abc.${local.alternate_subdomain_name}" = { zone_id = local.alternate_subdomain_zone_id }
   }
 
   wait_for_validation = true

--- a/examples/multiple-zones-dns-validation/main.tf
+++ b/examples/multiple-zones-dns-validation/main.tf
@@ -1,0 +1,94 @@
+locals {
+  # Use existing (via data source) or create new zones (will fail validation, if zone is not reachable)
+  use_existing_route53_zones = true
+
+  domain = "terraform-aws-modules.modules.tf"
+  alternate_domain = "terraform-aws-modules.modules-alt.tf"
+  alternate_subdomain = "sub.${local.alternate_domain}"
+
+  # Removing trailing dot from domains - just to be sure :)
+  domain_name = trimsuffix(local.domain, ".")
+  alternate_domain_name = trimsuffix(local.alternate_domain, ".")
+  alternate_subdomain_name = trimsuffix(local.alternate_subdomain, ".")
+}
+
+data "aws_route53_zone" "domain" {
+  count = local.use_existing_route53_zones ? 1 : 0
+
+  name         = local.domain_name
+  private_zone = false
+}
+
+data "aws_route53_zone" "alternate_domain" {
+  count = local.use_existing_route53_zones ? 1 : 0
+
+  name         = local.alternate_domain_name
+  private_zone = false
+}
+
+data "aws_route53_zone" "alternate_subdomain" {
+  count = local.use_existing_route53_zones ? 1 : 0
+
+  name         = local.alternate_subdomain_name
+  private_zone = false
+}
+
+resource "aws_route53_zone" "domain" {
+  count = !local.use_existing_route53_zones ? 1 : 0
+  name  = local.domain_name
+}
+
+resource "aws_route53_zone" "alternate_domain" {
+  count = !local.use_existing_route53_zones ? 1 : 0
+  name  = local.alternate_domain_name
+}
+
+resource "aws_route53_zone" "alternate_subdomain" {
+  count = !local.use_existing_route53_zones ? 1 : 0
+  name  = local.alternate_subdomain_name
+}
+
+resource "aws_route53_record" "alternate_subdomain_delegation" {
+  count = !local.use_existing_route53_zones ? 1 : 0
+  name  = local.alternate_subdomain_name
+  type  = "NS"
+  ttl   = 300
+  records = aws_route53_zone.alternate_subdomain.*.name_servers[0]
+  zone_id = aws_route53_zone.alternate_domain.*.zone_id[0]
+}
+
+module "acm" {
+  source = "../../"
+
+  domain_name = local.domain_name
+
+  subject_alternative_names = [
+    "*.alerts.${local.domain_name}",
+    "new.sub.${local.domain_name}",
+    "*.${local.domain_name}",
+    "alerts.${local.domain_name}",
+    local.alternate_domain_name,
+    "*.${local.alternate_domain_name}",
+    "quite.deep.abc.sub.${local.alternate_domain_name}",
+    "def.${local.alternate_subdomain_name}",
+    "*.${local.alternate_subdomain_name}",
+  ]
+
+  domain_zones = {
+    (local.domain_name) = {
+      zone_id = coalescelist(data.aws_route53_zone.domain.*.zone_id, aws_route53_zone.domain.*.zone_id)[0]
+    }
+    (local.alternate_domain_name) = {
+      zone_id = coalescelist(data.aws_route53_zone.alternate_domain.*.zone_id, aws_route53_zone.alternate_domain.*.zone_id)[0]
+    }
+    (local.alternate_subdomain_name) = {
+      zone_id = coalescelist(data.aws_route53_zone.alternate_subdomain.*.zone_id, aws_route53_zone.alternate_subdomain.*.zone_id)[0]
+    }
+  }
+
+  wait_for_validation = true
+
+  tags = {
+    Name = local.domain_name
+  }
+}

--- a/examples/multiple-zones-dns-validation/outputs.tf
+++ b/examples/multiple-zones-dns-validation/outputs.tf
@@ -19,21 +19,11 @@ output "validation_route53_record_fqdns" {
 }
 
 output "distinct_domain_names" {
-  description = "List of distinct domains names used for the validation."
+  description = "List of distinct domains names used for validation. It does not include the certificate distinct domain names that were not mapped to a hosted zone."
   value       = module.acm.distinct_domain_names
 }
 
-output "distinct_domain_names_without_matching_zone" {
-  description = "List of distinct domains names that must be used for the validation but for which no Route 53 zone could be determined from the given input."
-  value       = module.acm.distinct_domain_names_without_matching_zone
-}
-
 output "validation_domains" {
-  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
+  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards. It does not include the domain validation options for the certificate distinct domain names that were not mapped to a hosted zone."
   value       = module.acm.validation_domains
-}
-
-output "validation_domains_without_matching_zone" {
-  description = "List of distinct domain validation options for which validation records have not been created because no Route 53 zone could be determined from the given input."
-  value       = module.acm.validation_domains_without_matching_zone
 }

--- a/examples/multiple-zones-dns-validation/outputs.tf
+++ b/examples/multiple-zones-dns-validation/outputs.tf
@@ -1,39 +1,39 @@
 output "acm_certificate_arn" {
   description = "The ARN of the certificate"
-  value       = element(concat(aws_acm_certificate_validation.this.*.certificate_arn, aws_acm_certificate.this.*.arn, [""]), 0)
+  value       = module.acm.acm_certificate_arn
 }
 
 output "acm_certificate_domain_validation_options" {
   description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
-  value       = flatten(aws_acm_certificate.this.*.domain_validation_options)
+  value       = module.acm.acm_certificate_domain_validation_options
 }
 
 output "acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
-  value       = flatten(aws_acm_certificate.this.*.validation_emails)
+  value       = module.acm.acm_certificate_validation_emails
 }
 
 output "validation_route53_record_fqdns" {
   description = "List of FQDNs built using the zone domain and name."
-  value       = aws_route53_record.validation.*.fqdn
+  value       = module.acm.validation_route53_record_fqdns
 }
 
 output "distinct_domain_names" {
   description = "List of distinct domains names used for the validation."
-  value       = local.distinct_domain_names
+  value       = module.acm.distinct_domain_names
 }
 
 output "distinct_domain_names_without_matching_zone" {
   description = "List of distinct domains names that must be used for the validation but for which no Route 53 zone could be determined from the given input."
-  value       = local.distinct_domain_names_without_matching_zone
+  value       = module.acm.distinct_domain_names_without_matching_zone
 }
 
 output "validation_domains" {
   description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
-  value       = local.validation_domains
+  value       = module.acm.validation_domains
 }
 
 output "validation_domains_without_matching_zone" {
-  description = "List of distinct domain validation options for which validation records have not been created because no Route 53 zone could be determined from the given input. This is useful for creating the validation records outside this module."
-  value       = local.validation_domains_without_matching_zone
+  description = "List of distinct domain validation options for which validation records have not been created because no Route 53 zone could be determined from the given input."
+  value       = module.acm.validation_domains_without_matching_zone
 }

--- a/examples/multiple-zones-dns-validation/versions.tf
+++ b/examples/multiple-zones-dns-validation/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = ">= 2.53"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,73 @@
 locals {
   # Get distinct list of domains and SANs
-  distinct_domain_names = distinct(
+  distinct_domain_names = tolist(distinct(
     [for s in concat([var.domain_name], var.subject_alternative_names) : replace(s, "*.", "")]
+  ))
+  # The subset of distinct domain names which we can map to a hosted zone
+  distinct_domain_names_with_matching_zone = (
+    length(var.domain_zones) == 0
+      ? local.distinct_domain_names
+      : [for d in local.distinct_domain_names : d
+           if 0 < length([for k in keys(var.domain_zones) : 1
+                            if lower(d) == lower(k) || trimsuffix(lower(d), lower(format(".%s", k))) != lower(d)])
+        ]
   )
+  # Output: the subset of distinct domain names which we cannot map to a hosted zone
+  distinct_domain_names_without_matching_zone = tolist([
+    for d in local.distinct_domain_names : d
+      if !contains(local.distinct_domain_names_with_matching_zone, d)
+  ])
 
   # Get the list of distinct domain_validation_options, with wildcard
   # domain names replaced by the domain name
-  validation_domains = var.create_certificate ? distinct(
-    [for k, v in aws_acm_certificate.this[0].domain_validation_options : merge(
-      tomap(v), { domain_name = replace(v.domain_name, "*.", "") }
-    )]
-  ) : []
+  validation_domains = tolist(
+    var.create_certificate ? distinct(
+      [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(merge(
+         v, { domain_name = replace(v.domain_name, "*.", "") }
+      ))]
+    ) : []
+  )
+
+  # The subset of the domain validation options from which we can create records
+  validation_domains_with_matching_zone = var.create_certificate ? distinct(
+    [for k, v in aws_acm_certificate.this[0].domain_validation_options :
+      merge(v, { domain_name = replace(v.domain_name, "*.", "") })
+        if contains(local.distinct_domain_names_with_matching_zone, replace(v.domain_name, "*.", ""))
+    ]) : []
+  # Output: the subset of the domain validation options for which we cannot create records
+  validation_domains_without_matching_zone = tolist(distinct(
+    var.create_certificate ? [
+      for k, v in aws_acm_certificate.this[0].domain_validation_options :
+        tomap(merge(v, { domain_name = replace(v.domain_name, "*.", "") }))
+          if contains(local.distinct_domain_names_without_matching_zone, replace(v.domain_name, "*.", ""))
+      ] : []
+  ))
+
+  # Prepare map for iterating over the keys of var.domain_zones in the order
+  # of their length, from the longest one to the shortest one
+  name_max_length = max(concat([0], [for n in keys(var.domain_zones) : length(n) ])...)
+  name_format = "%0${local.name_max_length}d_%s"
+  domains_by_name_length = {
+    for n, v in var.domain_zones :
+      format(local.name_format, length(n), n) => merge(v, { domain = n })
+  }
+
+  # For each item in validation_domains_with_matching_zone map to a zone_id from
+  # var.domain_zones or, if var.domain_zones is empty, to var.zone_id.
+  zone_ids = var.create_certificate ? [
+    for vd in local.validation_domains_with_matching_zone : (
+      length(var.domain_zones) == 0
+        ? var.zone_id
+        : element([for k in reverse(keys(local.domains_by_name_length)) :
+                     local.domains_by_name_length[k].zone_id
+                     # Is the FQDN a parent of the fully-qualified validation record name?
+                     if trimsuffix(
+                       lower(vd.resource_record_name),  # already FQDN
+                       lower(".${local.domains_by_name_length[k].domain}.")
+                     ) != lower(vd.resource_record_name)
+                  ], 0)
+    )
+  ] : []
 }
 
 resource "aws_acm_certificate" "this" {
@@ -32,15 +89,15 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
-  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names_with_matching_zone) : 0
 
-  zone_id = var.zone_id
-  name    = element(local.validation_domains, count.index)["resource_record_name"]
-  type    = element(local.validation_domains, count.index)["resource_record_type"]
+  zone_id = element(local.zone_ids, count.index)
+  name    = element(local.validation_domains_with_matching_zone, count.index)["resource_record_name"]
+  type    = element(local.validation_domains_with_matching_zone, count.index)["resource_record_type"]
   ttl     = var.dns_ttl
 
   records = [
-    element(local.validation_domains, count.index)["resource_record_value"]
+    element(local.validation_domains_with_matching_zone, count.index)["resource_record_value"]
   ]
 
   allow_overwrite = var.validation_allow_overwrite_records

--- a/main.tf
+++ b/main.tf
@@ -1,73 +1,19 @@
 locals {
-  # Get distinct list of domains and SANs
-  distinct_domain_names = tolist(distinct(
-    [for s in concat([var.domain_name], var.subject_alternative_names) : replace(s, "*.", "")]
-  ))
-  # The subset of distinct domain names which we can map to a hosted zone
-  distinct_domain_names_with_matching_zone = (
-    length(var.domain_zones) == 0
-      ? local.distinct_domain_names
-      : [for d in local.distinct_domain_names : d
-           if 0 < length([for k in keys(var.domain_zones) : 1
-                            if lower(d) == lower(k) || trimsuffix(lower(d), lower(format(".%s", k))) != lower(d)])
-        ]
+  # Get distinct list of domains and SANs that can be mapped to a zone
+  distinct_domain_names = distinct(
+    [for s in concat([var.domain_name], var.subject_alternative_names) : replace(s, "*.", "")
+      if length(var.domain_zones) == 0 || contains(keys(var.domain_zones), s)
+    ]
   )
-  # Output: the subset of distinct domain names which we cannot map to a hosted zone
-  distinct_domain_names_without_matching_zone = tolist([
-    for d in local.distinct_domain_names : d
-      if !contains(local.distinct_domain_names_with_matching_zone, d)
-  ])
 
   # Get the list of distinct domain_validation_options, with wildcard
-  # domain names replaced by the domain name
-  validation_domains = tolist(
-    var.create_certificate ? distinct(
-      [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(merge(
-         v, { domain_name = replace(v.domain_name, "*.", "") }
-      ))]
-    ) : []
-  )
-
-  # The subset of the domain validation options from which we can create records
-  validation_domains_with_matching_zone = var.create_certificate ? distinct(
-    [for k, v in aws_acm_certificate.this[0].domain_validation_options :
-      merge(v, { domain_name = replace(v.domain_name, "*.", "") })
-        if contains(local.distinct_domain_names_with_matching_zone, replace(v.domain_name, "*.", ""))
-    ]) : []
-  # Output: the subset of the domain validation options for which we cannot create records
-  validation_domains_without_matching_zone = tolist(distinct(
-    var.create_certificate ? [
-      for k, v in aws_acm_certificate.this[0].domain_validation_options :
-        tomap(merge(v, { domain_name = replace(v.domain_name, "*.", "") }))
-          if contains(local.distinct_domain_names_without_matching_zone, replace(v.domain_name, "*.", ""))
-      ] : []
-  ))
-
-  # Prepare map for iterating over the keys of var.domain_zones in the order
-  # of their length, from the longest one to the shortest one
-  name_max_length = max(concat([0], [for n in keys(var.domain_zones) : length(n) ])...)
-  name_format = "%0${local.name_max_length}d_%s"
-  domains_by_name_length = {
-    for n, v in var.domain_zones :
-      format(local.name_format, length(n), n) => merge(v, { domain = n })
-  }
-
-  # For each item in validation_domains_with_matching_zone map to a zone_id from
-  # var.domain_zones or, if var.domain_zones is empty, to var.zone_id.
-  zone_ids = var.create_certificate ? [
-    for vd in local.validation_domains_with_matching_zone : (
-      length(var.domain_zones) == 0
-        ? var.zone_id
-        : element([for k in reverse(keys(local.domains_by_name_length)) :
-                     local.domains_by_name_length[k].zone_id
-                     # Is the FQDN a parent of the fully-qualified validation record name?
-                     if trimsuffix(
-                       lower(vd.resource_record_name),  # already FQDN
-                       lower(".${local.domains_by_name_length[k].domain}.")
-                     ) != lower(vd.resource_record_name)
-                  ], 0)
-    )
-  ] : []
+  # domain names replaced by the domain name. Validation records will be
+  # created from this list.
+  validation_domains = var.create_certificate ? distinct(
+    [for k, v in aws_acm_certificate.this[0].domain_validation_options : tomap(merge(
+       v, { domain_name = replace(v.domain_name, "*.", "") }
+    )) if contains(local.distinct_domain_names, replace(v.domain_name, "*.", ""))]
+  ) : []
 }
 
 resource "aws_acm_certificate" "this" {
@@ -89,15 +35,19 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
-  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names_with_matching_zone) : 0
+  count = var.create_certificate && var.validation_method == "DNS" && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
-  zone_id = element(local.zone_ids, count.index)
-  name    = element(local.validation_domains_with_matching_zone, count.index)["resource_record_name"]
-  type    = element(local.validation_domains_with_matching_zone, count.index)["resource_record_type"]
+  zone_id = (
+    length(var.domain_zones) == 0
+      ? var.zone_id
+      : var.domain_zones[element(local.validation_domains, count.index)["domain_name"]]["zone_id"]
+  )
+  name    = element(local.validation_domains, count.index)["resource_record_name"]
+  type    = element(local.validation_domains, count.index)["resource_record_type"]
   ttl     = var.dns_ttl
 
   records = [
-    element(local.validation_domains_with_matching_zone, count.index)["resource_record_value"]
+    element(local.validation_domains, count.index)["resource_record_value"]
   ]
 
   allow_overwrite = var.validation_allow_overwrite_records

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,21 +19,11 @@ output "validation_route53_record_fqdns" {
 }
 
 output "distinct_domain_names" {
-  description = "List of distinct domains names used for the validation."
+  description = "List of distinct domains names used for validation. It does not include the certificate distinct domain names that were not mapped to a hosted zone."
   value       = local.distinct_domain_names
 }
 
-output "distinct_domain_names_without_matching_zone" {
-  description = "List of distinct domains names that must be used for the validation but for which no Route 53 zone could be determined from the given input."
-  value       = local.distinct_domain_names_without_matching_zone
-}
-
 output "validation_domains" {
-  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards."
+  description = "List of distinct domain validation options. This is useful if subject alternative names contain wildcards. It does not include the domain validation options for the certificate distinct domain names that were not mapped to a hosted zone."
   value       = local.validation_domains
-}
-
-output "validation_domains_without_matching_zone" {
-  description = "List of distinct domain validation options for which validation records have not been created because no Route 53 zone could be determined from the given input. This is useful for creating the validation records outside this module."
-  value       = local.validation_domains_without_matching_zone
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "create_certificate" {
 }
 
 variable "validate_certificate" {
-  description = "Whether to validate certificate by creating Route53 record"
+  description = "Whether to validate certificate by creating Route53 record(s)"
   type        = bool
   default     = true
 }
@@ -47,9 +47,18 @@ variable "validation_method" {
 }
 
 variable "zone_id" {
-  description = "The ID of the hosted zone to contain this record."
+  description = "The ID of the hosted zone to contain the validation record(s)."
   type        = string
   default     = ""
+}
+
+variable "domain_zones" {
+  description = "A mappping of distinct domain names to Route 53 zone ids."
+  type        = map(any)
+  # domain_name => object({
+  #  zone_id = string
+  # }))
+  default     = {}
 }
 
 variable "tags" {
@@ -59,7 +68,7 @@ variable "tags" {
 }
 
 variable "dns_ttl" {
-  description = "The TTL of DNS recursive resolvers to cache information about this record."
+  description = "The TTL of DNS recursive resolvers to cache information about the validation record(s)."
   type        = number
   default     = 60
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,11 +53,8 @@ variable "zone_id" {
 }
 
 variable "domain_zones" {
-  description = "A mappping of distinct domain names to Route 53 zone ids."
+  description = "A mapping of distinct domain names to Route 53 zone details."
   type        = map(any)
-  # domain_name => object({
-  #  zone_id = string
-  # }))
   default     = {}
 }
 


### PR DESCRIPTION
## Description

The proposed change is based on what I think is a simple idea: taking as input a mapping from domain names to publicly hosted Route 53 zone ids, for every record necessary for validation, find the best matching zone that can contain the validation record and create the record into that zone. The best matching zone is found by iterating over all the domain names mapped to hosted zones, from the longest one to the shortest one, and checking if the current fully-qualified domain name is a parent of the fully-qualified name in `resource_record_name`.

The `locals` section becomes bigger and maybe too verbose, but I'll try to explain the changes in a little more details:
- the module receives as input an optional mapping from domain names (public zones names) to zone ids
- build two subsets of `local.distinct_domain_names` and `local.validation_domains`. One subset contains the items that will be used to create the validation records, one subset contains the items for which validation records cannot be created by the module because they cannot be hosted in the zones given as input
- each validation record is created into the zone with the longest matching domain
- the two subsets for which validation records cannot be created are used as module outputs so that the users of the module can create the validation records outside the module
- some `locals` used as module outputs are changed slightly to have normalized types

An example is added too: it shows an ACM certificate with requires validation records in three zones. In the set of three zones, one zone has a subdomain delegation to another zone.

There are no documentation changes yet. I would like to see first if the idea is in the good direction.

## Motivation and Context

There is high interest in creating ACM certificates with multiple domains in them (#21). My particular use-case is multiple domains ACM certificates for using on CloudFront distributions.

This change or the idea from this change, if accepted, would allow the module to cover more use-cases:
- validation of ACM certificates with multiple domains, for example: `domain_one`, `*.domain_one`, `domain_two`, `*.domain_two`, where `domain_one` is hosted in one Route 53 zone and `domain_two` is hosted in another Route 53 zone
- validation of ACM certificates with one or more parent domains and subdomains, for example: `example.com`, `my.example.com`, `a.little.deep.my.example.com`, with `example.com` hosted in one Route 53 zone and delegating `my.example.com` to another Route 53 hosted zone
- for ACM certificates with domains hosted on both Route 53 zones and third-party providers, the creation of the Route 53 validation records part. The user of the module, by setting `wait_for_validation` to false and using the `validation_domains_without_matching_zone` output , will be able to create the records at the third-party provides and complete the validation. For example: domains `example.com` and `example.org` in the certificate, domain `example.com` hosted in a Route 53 zone, domain `example.org` hosted somewhere else.


## Breaking Changes

The change adds a new input and new outputs and the new logic is applied when using the new input variable.

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
