### PR TITLE
check for certificate on validation_domains

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 
   # Get the list of distinct domain_validation_options, with wildcard
   # domain names replaced by the domain name
-  validation_domains = var.create_certificate ? distinct(
+  validation_domains = (var.create_certificate && length(aws_acm_certificate.this) > 0) ? distinct(
     [for k, v in aws_acm_certificate.this[0].domain_validation_options : merge(
       tomap(v), { domain_name = replace(v.domain_name, "*.", "") }
     )]


### PR DESCRIPTION
when validation has timed out, an exception is thrown:
```
13:32:58 | validation_domains = var.create_certificate ? [for k, v in aws_acm_certificate.this+[0]+.domain_validation_options : tomap(v) if contains(local.distinct_domain_names, replace(v.domain_name, ".", ""))] : []
13:32:58 |----------------
13:32:58 | aws_acm_certificate.this is empty tuple
13:32:58
13:32:58 The given key does not identify an element in this collection value.
```

this exception is thrown also when attempting destory