### PR TITLE
feat!: Added validation_option configuration and upgraded AWS provider to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ module "acm" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.53 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.12.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.53 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
 
 ## Modules
 
@@ -157,6 +157,7 @@ No modules.
 | <a name="input_validate_certificate"></a> [validate\_certificate](#input\_validate\_certificate) | Whether to validate certificate by creating Route53 record | `bool` | `true` | no |
 | <a name="input_validation_allow_overwrite_records"></a> [validation\_allow\_overwrite\_records](#input\_validation\_allow\_overwrite\_records) | Whether to allow overwrite of Route53 records | `bool` | `true` | no |
 | <a name="input_validation_method"></a> [validation\_method](#input\_validation\_method) | Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform. | `string` | `"DNS"` | no |
+| <a name="input_validation_option"></a> [validation\_option](#input\_validation\_option) | The domain name that you want ACM to use to send you validation emails. This domain name is the suffix of the email addresses that you want ACM to use. | `map(string)` | `{}` | no |
 | <a name="input_validation_record_fqdns"></a> [validation\_record\_fqdns](#input\_validation\_record\_fqdns) | When validation is set to DNS and the DNS validation records are set externally, provide the fqdns for the validation | `list(string)` | `[]` | no |
 | <a name="input_wait_for_validation"></a> [wait\_for\_validation](#input\_wait\_for\_validation) | Whether to wait for the validation to complete | `bool` | `true` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | The ID of the hosted zone to contain this record. Required when validating via Route53 | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ module "acm" {
 - [Complete example with DNS validation (recommended)](https://github.com/terraform-aws-modules/terraform-aws-acm/tree/master/examples/complete-dns-validation)
 - [Complete example with DNS validation via external DNS provider (CloudFlare)](https://github.com/terraform-aws-modules/terraform-aws-acm/tree/master/examples/complete-dns-validation-with-cloudflare)
 - [Complete example with EMAIL validation](https://github.com/terraform-aws-modules/terraform-aws-acm/tree/master/examples/complete-email-validation)
+- [Complete example with EMAIL validation and validation domain override](https://github.com/terraform-aws-modules/terraform-aws-acm/tree/master/examples/complete-email-validation-with-validation-domain)
 
 ## Conditional creation and validation
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ module "acm" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.12.0 |
 
 ## Providers

--- a/examples/complete-email-validation-with-validation-domain/README.md
+++ b/examples/complete-email-validation-with-validation-domain/README.md
@@ -1,0 +1,70 @@
+# Complete ACM example with EMAIL validation with validation_domain configured
+
+Configuration in this directory creates new Route53 zone and ACM certificate (valid for the domain name and wildcard).
+
+ACM certificate will be created with EMAIL validation method, which means that emails will be send to domain owners and it is not possible to automate using Terraform!
+The validation domain option is set, which overrides the domain to which validation emails will be sent.
+
+If you want to use EMAIL validation method make sure that you have access to at least one of these emails in your domain:
+
+```
+hostmaster@VALIDATION_DOMAIN
+postmaster@VALIDATION_DOMAIN
+admin@VALIDATION_DOMAIN
+administrator@VALIDATION_DOMAIN
+webmaster@VALIDATION_DOMAIN
+```
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var 'domain_name=foo.bar.com' -var 'validation_domain=bar.com'
+$ terraform apply -var 'domain_name=foo.bar.com' -var 'validation_domain=bar.com'
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.12.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.12.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acm"></a> [acm](#module\_acm) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name to use as Route53 zone and ACM certificate | `string` | n/a | yes |
+| <a name="input_validation_domain"></a> [validation\_domain](#input\_validation\_domain) | Domain name to use for verifying var.domain\_name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | The ARN of the certificate |
+| <a name="output_acm_certificate_domain_validation_options"></a> [acm\_certificate\_domain\_validation\_options](#output\_acm\_certificate\_domain\_validation\_options) | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| <a name="output_acm_certificate_validation_emails"></a> [acm\_certificate\_validation\_emails](#output\_acm\_certificate\_validation\_emails) | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-email-validation-with-validation-domain/README.md
+++ b/examples/complete-email-validation-with-validation-domain/README.md
@@ -32,7 +32,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.12.0 |
 
 ## Providers

--- a/examples/complete-email-validation-with-validation-domain/main.tf
+++ b/examples/complete-email-validation-with-validation-domain/main.tf
@@ -8,11 +8,12 @@ module "acm" {
   domain_name = var.domain_name
   zone_id     = aws_route53_zone.this.zone_id
 
-  # the key is the domain name which you want to change the validation domain for. validation emails will be send to a fixed list of recipients:
+  # The key is the domain name which you want to change the validation domain for.
+  # Validation emails will be send to a fixed list of recipients:
   # admin@VALIDATION_DOMAIN, administrator@VALIDATION_DOMAIN, hostmaster@VALIDATION_DOMAIN, postmaster@VALIDATION_DOMAIN, webmaster@VALIDATION_DOMAIN
   # validation_domain has to be a top-level domain of the actual domain
   validation_option = {
-    "${var.domain_name}" = {
+    (var.domain_name) = {
       validation_domain = var.validation_domain
     }
   }

--- a/examples/complete-email-validation-with-validation-domain/main.tf
+++ b/examples/complete-email-validation-with-validation-domain/main.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "this" {
+  name = var.domain_name
+}
+
+module "acm" {
+  source = "../../"
+
+  domain_name = var.domain_name
+  zone_id     = aws_route53_zone.this.zone_id
+
+  # the key is the domain name which you want to change the validation domain for. validation emails will be send to a fixed list of recipients:
+  # admin@VALIDATION_DOMAIN, administrator@VALIDATION_DOMAIN, hostmaster@VALIDATION_DOMAIN, postmaster@VALIDATION_DOMAIN, webmaster@VALIDATION_DOMAIN
+  # validation_domain has to be a top-level domain of the actual domain
+  validation_option = {
+    "${var.domain_name}" = {
+      validation_domain = var.validation_domain
+    }
+  }
+
+  validation_method   = "EMAIL"
+  wait_for_validation = false
+
+  tags = {
+    Name = var.domain_name
+  }
+}

--- a/examples/complete-email-validation-with-validation-domain/outputs.tf
+++ b/examples/complete-email-validation-with-validation-domain/outputs.tf
@@ -1,0 +1,14 @@
+output "acm_certificate_arn" {
+  description = "The ARN of the certificate"
+  value       = module.acm.acm_certificate_arn
+}
+
+output "acm_certificate_domain_validation_options" {
+  description = "A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used."
+  value       = module.acm.acm_certificate_domain_validation_options
+}
+
+output "acm_certificate_validation_emails" {
+  description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
+  value       = module.acm.acm_certificate_validation_emails
+}

--- a/examples/complete-email-validation-with-validation-domain/variables.tf
+++ b/examples/complete-email-validation-with-validation-domain/variables.tf
@@ -1,0 +1,9 @@
+variable "domain_name" {
+  description = "Domain name to use as Route53 zone and ACM certificate"
+  type        = string
+}
+
+variable "validation_domain" {
+  description = "Domain name to use for verifying var.domain_name"
+  type        = string
+}

--- a/examples/complete-email-validation-with-validation-domain/versions.tf
+++ b/examples/complete-email-validation-with-validation-domain/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/complete-email-validation-with-validation-domain/versions.tf
+++ b/examples/complete-email-validation-with-validation-domain/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.12.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,15 @@ resource "aws_acm_certificate" "this" {
     certificate_transparency_logging_preference = var.certificate_transparency_logging_preference ? "ENABLED" : "DISABLED"
   }
 
+  dynamic "validation_option" {
+    for_each = var.validation_option
+
+    content {
+      domain_name       = try(validation_option.value["domain_name"], validation_option.key)
+      validation_domain = validation_option.value["validation_domain"]
+    }
+  }
+
   tags = var.tags
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "validation_method" {
   }
 }
 
+variable "validation_option" {
+  description = "The domain name that you want ACM to use to send you validation emails. This domain name is the suffix of the email addresses that you want ACM to use."
+  type        = map(string)
+  default     = {}
+}
+
 variable "create_route53_records" {
   description = "When validation is set to DNS, define whether to create the DNS records internally via Route53 or externally using any DNS provider"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.53"
+      version = ">= 4.12.0"
     }
   }
 }


### PR DESCRIPTION
## Description
Adds `validation_domain` option as described in #105 

## Motivation and Context
The ACM-request option `--domain-validation-options ValidationDomain=bar.com,DomainName="foo.bar.com"` for modifying the domain used for sending the validation email to, couldnt be used yet as the TF-provider didnt support it. Finally, after only 4yrs being open, the PR got merged and its available in provider 4.12.0


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
