### PR TITLE
feat: Cross-account DNS and ACM resource creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 3.0"
 
+  providers = {
+    aws.acm = aws,
+    aws.dns = aws
+  }
+
   domain_name  = "my-domain.com"
   zone_id      = "Z2ES7B9AZ6SHAE"
 
@@ -33,6 +38,11 @@ module "acm" {
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 3.0"
+
+  providers = {
+    aws.acm = aws,
+    aws.dns = aws
+  }
 
   domain_name = "weekly.tf"
   zone_id     = "b7d259641bf30b89887c943ffc9d2138"
@@ -66,7 +76,8 @@ module "acm" {
   source = "terraform-aws-modules/acm/aws"
 
   providers = {
-    aws = aws.us-east-1
+    aws.acm = aws.us-east-1,
+    aws.dns = aws
   }
 
   domain_name = "my-domain.com"
@@ -94,6 +105,11 @@ Sometimes you need to have a way to create ACM certificate conditionally but Ter
 ```hcl
 module "acm" {
   source = "terraform-aws-modules/acm/aws"
+
+  providers = {
+    aws.acm = aws,
+    aws.dns = aws
+  }
 
   create_certificate = false
   # ... omitted
@@ -128,7 +144,8 @@ module "acm" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.53 |
+| <a name="provider_aws.acm"></a> [aws.acm](#provider\_aws.acm) | >= 2.53 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | >= 2.53 |
 
 ## Modules
 

--- a/examples/complete-dns-validation-with-cloudflare/main.tf
+++ b/examples/complete-dns-validation-with-cloudflare/main.tf
@@ -8,6 +8,11 @@ locals {
 module "acm" {
   source = "../../"
 
+  providers = {
+    aws.acm = aws,
+    aws.dns = aws
+  }
+
   domain_name = local.domain_name
   zone_id     = data.cloudflare_zone.this.id
 

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -23,6 +23,11 @@ resource "aws_route53_zone" "this" {
 module "acm" {
   source = "../../"
 
+  providers = {
+    aws.acm = aws,
+    aws.dns = aws
+  }
+
   domain_name = local.domain_name
   zone_id     = coalescelist(data.aws_route53_zone.this.*.zone_id, aws_route53_zone.this.*.zone_id)[0]
 

--- a/examples/complete-email-validation/main.tf
+++ b/examples/complete-email-validation/main.tf
@@ -5,6 +5,11 @@ resource "aws_route53_zone" "this" {
 module "acm" {
   source = "../../"
 
+  providers = {
+    aws.acm = aws,
+    aws.dns = aws
+  }
+
   domain_name = var.domain_name
   zone_id     = aws_route53_zone.this.zone_id
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,8 @@ locals {
 }
 
 resource "aws_acm_certificate" "this" {
-  count = local.create_certificate ? 1 : 0
+  provider = aws.acm
+  count    = local.create_certificate ? 1 : 0
 
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
@@ -34,7 +35,8 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "validation" {
-  count = local.create_certificate && var.validation_method == "DNS" && var.create_route53_records && var.validate_certificate ? length(local.distinct_domain_names) : 0
+  provider = aws.dns
+  count    = local.create_certificate && var.validation_method == "DNS" && var.create_route53_records && var.validate_certificate ? length(local.distinct_domain_names) : 0
 
   zone_id = var.zone_id
   name    = element(local.validation_domains, count.index)["resource_record_name"]
@@ -51,7 +53,8 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count = local.create_certificate && var.validation_method != "NONE" && var.validate_certificate && var.wait_for_validation ? 1 : 0
+  provider = aws.acm
+  count    = local.create_certificate && var.validation_method != "NONE" && var.validate_certificate && var.wait_for_validation ? 1 : 0
 
   certificate_arn = aws_acm_certificate.this[0].arn
 

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "acm"
+}
+
+provider "aws" {
+  alias = "dns"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "acm"
-}
-
-provider "aws" {
-  alias = "dns"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 2.53"
+      source                = "hashicorp/aws"
+      version               = ">= 2.53"
+      configuration_aliases = [aws.acm, aws.dns]
     }
   }
 }


### PR DESCRIPTION
## Description
The proposed changes will allow both cross-account and single account ACM creation with DNS validation.

## Motivation and Context
I needed to create my ACM certificates in account B but my hosted zone belongs to Account A. These changes allowed me to meet this requirement.

## Breaking Changes
I believe the two providers will now always be required and need to be explicitly passed down.

In the module call, people will now need to pass the providers block with the two required providers.

```hcl
  providers = {
    aws.acm = aws.account_b,
    aws.dns = aws.account_a
  }
```

or if they use a single account then the following block should still work

```hcl
  providers = {
    aws.acm = aws,
    aws.dns = aws
  }
```

## How Has This Been Tested?

I have tested by calling the fork with my branch

```hcl
module "acm" {
  source = "git@github.com:Pod-Point/terraform-aws-acm.git?ref=patch-cross-account-provider"

  providers = {
    aws.acm = aws.<ommited>,
    aws.dns = aws.<ommited>
  }

  domain_name = var.project_domain
  zone_id     = var.pod_point_hosted_zone_id

  subject_alternative_names = var.additional_aliased_domains

  wait_for_validation                = true
  validation_allow_overwrite_records = false
}
```

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
