### PR TITLE
feat: Added new output for certificate status

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ No modules.
 |------|-------------|
 | <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | The ARN of the certificate |
 | <a name="output_acm_certificate_domain_validation_options"></a> [acm\_certificate\_domain\_validation\_options](#output\_acm\_certificate\_domain\_validation\_options) | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | Status of the certificate. |
 | <a name="output_acm_certificate_validation_emails"></a> [acm\_certificate\_validation\_emails](#output\_acm\_certificate\_validation\_emails) | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
 | <a name="output_distinct_domain_names"></a> [distinct\_domain\_names](#output\_distinct\_domain\_names) | List of distinct domains names used for the validation. |
 | <a name="output_validation_domains"></a> [validation\_domains](#output\_validation\_domains) | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |

--- a/examples/complete-dns-validation-with-cloudflare/README.md
+++ b/examples/complete-dns-validation-with-cloudflare/README.md
@@ -56,6 +56,7 @@ No inputs.
 |------|-------------|
 | <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | The ARN of the certificate |
 | <a name="output_acm_certificate_domain_validation_options"></a> [acm\_certificate\_domain\_validation\_options](#output\_acm\_certificate\_domain\_validation\_options) | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | Status of the certificate. |
 | <a name="output_acm_certificate_validation_emails"></a> [acm\_certificate\_validation\_emails](#output\_acm\_certificate\_validation\_emails) | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
 | <a name="output_distinct_domain_names"></a> [distinct\_domain\_names](#output\_distinct\_domain\_names) | List of distinct domains names used for the validation. |
 | <a name="output_validation_domains"></a> [validation\_domains](#output\_validation\_domains) | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |

--- a/examples/complete-dns-validation-with-cloudflare/outputs.tf
+++ b/examples/complete-dns-validation-with-cloudflare/outputs.tf
@@ -10,7 +10,7 @@ output "acm_certificate_domain_validation_options" {
 
 output "acm_certificate_status" {
   description = "Status of the certificate."
-  value       = element(aws_acm_certificate.this.*.status, 0)
+  value       = module.acm.acm_certificate_status
 }
 
 output "acm_certificate_validation_emails" {

--- a/examples/complete-dns-validation-with-cloudflare/outputs.tf
+++ b/examples/complete-dns-validation-with-cloudflare/outputs.tf
@@ -8,6 +8,11 @@ output "acm_certificate_domain_validation_options" {
   value       = module.acm.acm_certificate_domain_validation_options
 }
 
+output "acm_certificate_status" {
+  description = "Status of the certificate."
+  value       = element(aws_acm_certificate.this.*.status, 0)
+}
+
 output "acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
   value       = module.acm.acm_certificate_validation_emails

--- a/examples/complete-dns-validation/README.md
+++ b/examples/complete-dns-validation/README.md
@@ -55,6 +55,7 @@ No inputs.
 |------|-------------|
 | <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | The ARN of the certificate |
 | <a name="output_acm_certificate_domain_validation_options"></a> [acm\_certificate\_domain\_validation\_options](#output\_acm\_certificate\_domain\_validation\_options) | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | Status of the certificate. |
 | <a name="output_acm_certificate_validation_emails"></a> [acm\_certificate\_validation\_emails](#output\_acm\_certificate\_validation\_emails) | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
 | <a name="output_distinct_domain_names"></a> [distinct\_domain\_names](#output\_distinct\_domain\_names) | List of distinct domains names used for the validation. |
 | <a name="output_validation_domains"></a> [validation\_domains](#output\_validation\_domains) | List of distinct domain validation options. This is useful if subject alternative names contain wildcards. |

--- a/examples/complete-dns-validation/outputs.tf
+++ b/examples/complete-dns-validation/outputs.tf
@@ -10,7 +10,7 @@ output "acm_certificate_domain_validation_options" {
 
 output "acm_certificate_status" {
   description = "Status of the certificate."
-  value       = element(aws_acm_certificate.this.*.status, 0)
+  value       = module.acm.acm_certificate_status
 }
 
 output "acm_certificate_validation_emails" {

--- a/examples/complete-dns-validation/outputs.tf
+++ b/examples/complete-dns-validation/outputs.tf
@@ -8,6 +8,11 @@ output "acm_certificate_domain_validation_options" {
   value       = module.acm.acm_certificate_domain_validation_options
 }
 
+output "acm_certificate_status" {
+  description = "Status of the certificate."
+  value       = element(aws_acm_certificate.this.*.status, 0)
+}
+
 output "acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
   value       = module.acm.acm_certificate_validation_emails

--- a/examples/complete-email-validation/README.md
+++ b/examples/complete-email-validation/README.md
@@ -69,5 +69,6 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|-------------|
 | <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | The ARN of the certificate |
 | <a name="output_acm_certificate_domain_validation_options"></a> [acm\_certificate\_domain\_validation\_options](#output\_acm\_certificate\_domain\_validation\_options) | A list of attributes to feed into other resources to complete certificate validation. Can have more than one element, e.g. if SANs are defined. Only set if DNS-validation was used. |
+| <a name="output_acm_certificate_status"></a> [acm\_certificate\_status](#output\_acm\_certificate\_status) | Status of the certificate. |
 | <a name="output_acm_certificate_validation_emails"></a> [acm\_certificate\_validation\_emails](#output\_acm\_certificate\_validation\_emails) | A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete-email-validation/outputs.tf
+++ b/examples/complete-email-validation/outputs.tf
@@ -10,7 +10,7 @@ output "acm_certificate_domain_validation_options" {
 
 output "acm_certificate_status" {
   description = "Status of the certificate."
-  value       = element(aws_acm_certificate.this.*.status, 0)
+  value       = module.acm.acm_certificate_status
 }
 
 output "acm_certificate_validation_emails" {

--- a/examples/complete-email-validation/outputs.tf
+++ b/examples/complete-email-validation/outputs.tf
@@ -8,6 +8,11 @@ output "acm_certificate_domain_validation_options" {
   value       = module.acm.acm_certificate_domain_validation_options
 }
 
+output "acm_certificate_status" {
+  description = "Status of the certificate."
+  value       = element(aws_acm_certificate.this.*.status, 0)
+}
+
 output "acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
   value       = module.acm.acm_certificate_validation_emails

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "acm_certificate_domain_validation_options" {
   value       = flatten(aws_acm_certificate.this.*.domain_validation_options)
 }
 
+output "acm_certificate_status" {
+  description = "Status of the certificate."
+  value       = element(aws_acm_certificate.this.*.status, 0)
+}
+
 output "acm_certificate_validation_emails" {
   description = "A list of addresses that received a validation E-Mail. Only set if EMAIL-validation was used."
   value       = flatten(aws_acm_certificate.this.*.validation_emails)

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "acm_certificate_domain_validation_options" {
 
 output "acm_certificate_status" {
   description = "Status of the certificate."
-  value       = element(aws_acm_certificate.this.*.status, 0)
+  value       = element(concat(aws_acm_certificate.this.*.status, [""]), 0)
 }
 
 output "acm_certificate_validation_emails" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding new output for certificate status. Supported attribute as mentioned in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#status .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/terraform-aws-modules/terraform-aws-acm/issues/109

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes, just adding a new output.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
