### PR TITLE
docs: URL for source

### DIFF
--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -14,7 +14,7 @@ This wrapper does not implement any extra functionality.
 terraform {
   source = "tfr:///terraform-aws-modules/acm/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-acm.git?ref=master//wrappers"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-acm.git//wrappers?ref=master"
 }
 
 inputs = {
@@ -72,7 +72,7 @@ module "wrapper" {
 terraform {
   source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=master//wrappers"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-acm.git//wrappers?ref=master"
 }
 
 inputs = {

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -72,7 +72,7 @@ module "wrapper" {
 terraform {
   source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-acm.git//wrappers?ref=master"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
 }
 
 inputs = {


### PR DESCRIPTION
## Description
Fix git URI for source:
```shell
ERRO[0008] 1 error occurred:
* error downloading 'ssh://git@github.com/terraform-aws-modules/terraform-aws-acm.git?ref=master%!F(MISSING)%!F(MISSING)wrappers': /opt/homebrew/bin/git exited with 1: error: pathspec 'master//wrappers' did not match any file(s) known to git
```

## How Has This Been Tested?
```shell
terraform init / terragrunt init
```