### PR TITLE
feat: Allow multiple domains in one cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ No modules.
 | <a name="input_validation_timeout"></a> [validation\_timeout](#input\_validation\_timeout) | Define maximum timeout to wait for the validation to complete | `string` | `null` | no |
 | <a name="input_wait_for_validation"></a> [wait\_for\_validation](#input\_wait\_for\_validation) | Whether to wait for the validation to complete | `bool` | `true` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | The ID of the hosted zone to contain this record. Required when validating via Route53 | `string` | `""` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Map containing the Route53 Zone IDs for additional domains. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/complete-dns-validation/README.md
+++ b/examples/complete-dns-validation/README.md
@@ -37,6 +37,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../ | n/a |
+| <a name="module_acm_multi_domain"></a> [acm\_multi\_domain](#module\_acm\_multi\_domain) | ../../ | n/a |
 | <a name="module_acm_only"></a> [acm\_only](#module\_acm\_only) | ../../ | n/a |
 | <a name="module_route53_records_only"></a> [route53\_records\_only](#module\_route53\_records\_only) | ../../ | n/a |
 
@@ -44,12 +45,18 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_route53_zone.extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain"></a> [domain](#input\_domain) | Domain to be used for the tests | `string` | `"terraform-aws-modules.modules.tf"` | no |
+| <a name="input_extra_domain"></a> [extra\_domain](#input\_extra\_domain) | Extr adomain to be used for the tests | `string` | `"extra.terraform-aws-modules.modules.tf"` | no |
+| <a name="input_use_existing_route53_zone"></a> [use\_existing\_route53\_zone](#input\_use\_existing\_route53\_zone) | Use existing (via data source) or create new zone (will fail validation, if zone is not reachable) | `bool` | `true` | no |
 
 ## Outputs
 

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -1,11 +1,14 @@
 locals {
   # Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)
-  use_existing_route53_zone = true
+  use_existing_route53_zone = var.use_existing_route53_zone
 
-  domain = "terraform-aws-modules.modules.tf"
+  domain       = var.domain
+  extra_domain = var.extra_domain
 
   # Removing trailing dot from domain - just to be sure :)
   domain_name = trimsuffix(local.domain, ".")
+
+  region = "us-east-1"
 
   zone_id = try(data.aws_route53_zone.this[0].zone_id, aws_route53_zone.this[0].zone_id)
 }
@@ -32,8 +35,7 @@ module "acm" {
   source = "../../"
 
   providers = {
-    aws.acm = aws,
-    aws.dns = aws
+    aws = aws.acm
   }
 
   domain_name = local.domain_name
@@ -58,11 +60,13 @@ module "acm" {
 ################################################################
 
 provider "aws" {
-  alias = "route53"
+  alias  = "route53"
+  region = local.region
 }
 
 provider "aws" {
-  alias = "acm"
+  alias  = "acm"
+  region = local.region
 }
 
 module "acm_only" {
@@ -98,4 +102,59 @@ module "route53_records_only" {
   distinct_domain_names = module.acm_only.distinct_domain_names
 
   acm_certificate_domain_validation_options = module.acm_only.acm_certificate_domain_validation_options
+}
+
+##########################################################
+# Example 3 (use multiple domains in the same certificate):
+# Generate an ACM certificate for multiple domains, useful
+# to be used in CloudFront which only supports one ACM
+# certificate.
+##########################################################
+
+provider "aws" {
+  region = local.region
+}
+
+data "aws_route53_zone" "extra" {
+  count = local.use_existing_route53_zone ? 1 : 0
+
+  name         = local.extra_domain
+  private_zone = false
+}
+
+resource "aws_route53_zone" "extra" {
+  count = !local.use_existing_route53_zone ? 1 : 0
+
+  name = local.extra_domain
+}
+
+module "acm_multi_domain" {
+  source = "../../"
+
+  domain_name = local.domain_name
+  zone_id     = local.zone_id
+
+  subject_alternative_names = [
+    "*.alerts.${local.domain_name}",
+    "new.sub.${local.domain_name}",
+    "*.${local.domain_name}",
+    "alerts.${local.domain_name}",
+    "*.alerts.${local.extra_domain}",
+    "new.sub.${local.extra_domain}",
+    "*.${local.extra_domain}",
+    "alerts.${local.extra_domain}",
+    local.extra_domain,
+    "*.${local.extra_domain}"
+  ]
+
+  zones = {
+    (local.extra_domain)            = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
+    "alerts.${local.extra_domain}"  = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id),
+    "new.sub.${local.extra_domain}" = try(data.aws_route53_zone.extra[0].zone_id, aws_route53_zone.extra[0].zone_id)
+  }
+
+  tags = {
+    Name         = local.domain_name
+    Extra_Domain = local.extra_domain
+  }
 }

--- a/examples/complete-dns-validation/variables.tf
+++ b/examples/complete-dns-validation/variables.tf
@@ -1,0 +1,17 @@
+variable "use_existing_route53_zone" {
+  description = "Use existing (via data source) or create new zone (will fail validation, if zone is not reachable)"
+  type        = bool
+  default     = true
+}
+
+variable "domain" {
+  description = "Domain to be used for the tests"
+  type        = string
+  default     = "terraform-aws-modules.modules.tf"
+}
+
+variable "extra_domain" {
+  description = "Extr adomain to be used for the tests"
+  type        = string
+  default     = "extra.terraform-aws-modules.modules.tf"
+}

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_acm_certificate" "this" {
 resource "aws_route53_record" "validation" {
   count = (local.create_certificate || local.create_route53_records_only) && var.validation_method == "DNS" && var.create_route53_records && (var.validate_certificate || local.create_route53_records_only) ? length(local.distinct_domain_names) : 0
 
-  zone_id = var.zone_id
+  zone_id = lookup(var.zones, element(local.validation_domains, count.index)["domain_name"], var.zone_id)
   name    = element(local.validation_domains, count.index)["resource_record_name"]
   type    = element(local.validation_domains, count.index)["resource_record_type"]
   ttl     = var.dns_ttl

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "zone_id" {
   default     = ""
 }
 
+variable "zones" {
+  description = "Map containing the Route53 Zone IDs for additional domains."
+  type        = map(string)
+  default     = {}
+}
+
 variable "tags" {
   description = "A mapping of tags to assign to the resource"
   type        = map(string)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -17,6 +17,7 @@ module "wrapper" {
   create_route53_records                      = try(each.value.create_route53_records, var.defaults.create_route53_records, true)
   validation_record_fqdns                     = try(each.value.validation_record_fqdns, var.defaults.validation_record_fqdns, [])
   zone_id                                     = try(each.value.zone_id, var.defaults.zone_id, "")
+  zones                                       = try(each.value.zones, var.defaults.zones, {})
   tags                                        = try(each.value.tags, var.defaults.tags, {})
   dns_ttl                                     = try(each.value.dns_ttl, var.defaults.dns_ttl, 60)
   acm_certificate_domain_validation_options   = try(each.value.acm_certificate_domain_validation_options, var.defaults.acm_certificate_domain_validation_options, {})


### PR DESCRIPTION
## Description
This PR allows creating one ACM certificate for multiple domains, which, is useful when using the certificate for CloudFront that only allows one certificate per distribution.

## Motivation and Context
CloudFront does not support multiple ACM certificates, like ALB. Therefore, if you need to support multiple domains in a single CloudFront distribution you would have to create the certificate manually because this module does not support it.

## Breaking Changes
This change should be backward compatible as I added a `zones` var containing a map with domains and their Route53 zone ID so the validation records are created in the correct Route53 zone.

Additionally, I have updated the tests in `examples/complete-dns-validation` to allow variables so it was easier for me (and others) to test with my test domains.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Fixes #136