### PR TITLE
chore: Add third example for multi-provider

### DIFF
--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -113,7 +113,7 @@ module "route53_records_only" {
 #
 #     configuration_aliases = [aws.acm, aws.dns]
 #
-# 3. Set your providers
+# 3. Modify resources in the module to use either the acm or dns provider
 # 4. Pass in your domains/zones/altnames as a list(object) to for_each
 # 5. Call the module with your respective providers like below
 ################################################################
@@ -142,8 +142,8 @@ module "route53_records_only" {
 #   for_each = local.domain_zones
 #
 #   providers = {
-#     aws.acm = aws.primary
-#     aws.dns = aws.legacy_dns
+#     aws.acm = aws.acm_provider
+#     aws.dns = aws.dns_provider
 #   }
 #
 #   domain_name = each.value.domain

--- a/examples/complete-dns-validation/main.tf
+++ b/examples/complete-dns-validation/main.tf
@@ -106,42 +106,55 @@ module "route53_records_only" {
 
 ################################################################
 # Example 3:
-# Using separate AWS providers for ACM and Route53 records.
-# Useful when these resources belong to different AWS accounts.
+# Use separate providers for ACM and Route53 with for_each
 #
 # 1. Clone this module into a local module
 # 2. Modify configuration_aliases for your aws provider:
 #
 #     configuration_aliases = [aws.acm, aws.dns]
 #
-# 3. Add a variable called `domain_zones` to pass in your different domain/zone
-# pairs in a map
-# 4. Call the module with your respective providers like below
+# 3. Set your providers
+# 4. Pass in your domains/zones/altnames as a list(object) to for_each
+# 5. Call the module with your respective providers like below
 ################################################################
-
-module "acm" {
-  source   = "../../modules/acm"
-  for_each = {
-    "domain1" = "zone1_id",
-    "domain2" = "zone2_id"
-  }
-
-  providers = {
-    aws.acm = aws.primary
-    aws.dns = aws.legacy_dns
-  }
-
-  domain_name = each.key
-  zone_id     = each.value
-
-  subject_alternative_names = [
-    "*.${each.key}",
-  ]
-
-  validation_method   = "DNS"
-  wait_for_validation = true
-
-  tags = {
-    Name = each.key
-  }
-}
+#
+# locals {
+#   domains_zones = [
+#     {
+#       domain = "example1.com",
+#       zone_id = "AAAAAAAAAAAAAA",
+#       subject_alt_names = [
+#         "*.example1.com"
+#       ]
+#     },
+#     {
+#       domain = "example2.com",
+#       zone_id = "BBBBBBBBBBBBBB",
+#       subject_alt_names = [
+#         "sub.example2.com"
+#       ]
+#     },
+#   ]
+# }
+#
+# module "acm" {
+#   source = "path/to/local/module"
+#   for_each = local.domain_zones
+#
+#   providers = {
+#     aws.acm = aws.primary
+#     aws.dns = aws.legacy_dns
+#   }
+#
+#   domain_name = each.value.domain
+#   zone_id     = each.value.zone_id
+#
+#   subject_alternative_names = each.value.subject_alt_names
+#
+#   validation_method   = "DNS"
+#   wait_for_validation = true
+#
+#   tags = {
+#     Name = each.value.domain
+#   }
+# }


### PR DESCRIPTION
## Description
This PR adds another example for multi-provider configuration when calling this module with `for_each`. I commented the example because pre-commit broke due to this needing to be implemented slightly differently than the others.

## Motivation and Context
In response to https://github.com/terraform-aws-modules/terraform-aws-acm/issues/146

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
