### PR TITLE
feat: Bump aws provider to 5.0

### DIFF
--- a/examples/complete-dns-validation-with-cloudflare/versions.tf
+++ b/examples/complete-dns-validation-with-cloudflare/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 5.0"
     }
     # Terraform v1.0.0 only functional with cloudflare versions less than or equal to 3.33.0
     # https://github.com/cloudflare/terraform-provider-cloudflare/issues/2340

--- a/examples/complete-dns-validation/versions.tf
+++ b/examples/complete-dns-validation/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete-email-validation-with-validation-domain/versions.tf
+++ b/examples/complete-email-validation-with-validation-domain/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 5.0"
     }
   }
 }

--- a/examples/complete-email-validation/versions.tf
+++ b/examples/complete-email-validation/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 5.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.40"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## Description

I need some terraform features that are only available in terraform 5.0, and I'm unable to use it because of this module provider version. So I'm opening this PR to bump it to 5.0

## Motivation and Context
Conflicts between the provider configuration of the module and of my project

## Breaking Changes
It appears that does not break anything, since I used my fork's version in my project and no changes to the ACM config were found.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
